### PR TITLE
feat: fire session init/destroy and ui init events via bean manager

### DIFF
--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/service/EventObserver.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/service/EventObserver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2000-2018 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.quarkus.it.service;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import com.vaadin.flow.quarkus.it.Counter;
+import com.vaadin.flow.server.SessionDestroyEvent;
+import com.vaadin.flow.server.SessionInitEvent;
+import com.vaadin.flow.server.UIInitEvent;
+
+public class EventObserver {
+    @Inject
+    private Counter counter;
+
+    private void onSessionInit(@Observes SessionInitEvent sessionInitEvent) {
+        counter.increment(SessionInitEvent.class.getSimpleName());
+    }
+
+    private void onSessionDestroy(
+            @Observes SessionDestroyEvent sessionDestroyEvent) {
+        counter.increment(SessionDestroyEvent.class.getSimpleName());
+    }
+
+    private void onUIInit(@Observes UIInitEvent uiInitEvent) {
+        counter.increment(UIInitEvent.class.getSimpleName());
+    }
+}

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/EventsTest.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/EventsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2021 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.quarkus.it;
+
+import java.io.IOException;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import com.vaadin.flow.quarkus.it.service.ServiceView;
+import com.vaadin.flow.server.SessionDestroyEvent;
+import com.vaadin.flow.server.SessionInitEvent;
+import com.vaadin.flow.server.UIInitEvent;
+
+@QuarkusTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class EventsTest extends AbstractCdiTest {
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        resetCounts();
+    }
+
+    @Override
+    protected String getTestPath() {
+        return "/service";
+    }
+
+    @Test
+    @Disabled
+    public void sessionInitEventObserved() throws IOException {
+        String initCounter = SessionInitEvent.class.getSimpleName();
+        assertCountEquals(0, initCounter);
+        getDriver().manage().deleteAllCookies();
+        open();
+        assertCountEquals(1, initCounter);
+    }
+
+    @Test
+    @Disabled
+    public void sessionDestroyEventObserved() throws IOException {
+        String destroyCounter = SessionDestroyEvent.class.getSimpleName();
+        assertCountEquals(0, destroyCounter);
+        open();
+        assertCountEquals(0, destroyCounter);
+        click(ServiceView.EXPIRE);
+        assertCountEquals(1, destroyCounter);
+    }
+
+    @Test
+    @Disabled
+    public void uiInitEventObserved() throws IOException {
+        String uiInitCounter = UIInitEvent.class.getSimpleName();
+        assertCountEquals(0, uiInitCounter);
+        open();
+        assertCountEquals(1, uiInitCounter);
+    }
+
+}

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/ServiceTest.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/ServiceTest.java
@@ -26,6 +26,10 @@ import org.junit.jupiter.api.TestInstance;
 
 import com.vaadin.flow.quarkus.it.service.BootstrapCustomizer;
 import com.vaadin.flow.quarkus.it.service.ServiceBean;
+import com.vaadin.flow.quarkus.it.service.ServiceView;
+import com.vaadin.flow.server.SessionDestroyEvent;
+import com.vaadin.flow.server.SessionInitEvent;
+import com.vaadin.flow.server.UIInitEvent;
 
 @QuarkusTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -65,6 +69,33 @@ public class ServiceTest extends AbstractCdiTest {
         Assertions.assertEquals(id, getText("service-id"));
         count = getCount(ServiceBean.class.getName());
         Assertions.assertEquals(1, count);
+    }
+
+    @Test
+    public void sessionInitEventObserved() throws IOException {
+        String initCounter = SessionInitEvent.class.getSimpleName();
+        assertCountEquals(0, initCounter);
+        getDriver().manage().deleteAllCookies();
+        open();
+        assertCountEquals(1, initCounter);
+    }
+
+    @Test
+    public void sessionDestroyEventObserved() throws IOException {
+        String destroyCounter = SessionDestroyEvent.class.getSimpleName();
+        assertCountEquals(0, destroyCounter);
+        open();
+        assertCountEquals(0, destroyCounter);
+        click(ServiceView.EXPIRE);
+        assertCountEquals(1, destroyCounter);
+    }
+
+    @Test
+    public void uiInitEventObserved() throws IOException {
+        String uiInitCounter = UIInitEvent.class.getSimpleName();
+        assertCountEquals(0, uiInitCounter);
+        open();
+        assertCountEquals(1, uiInitCounter);
     }
 
 }

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/ServiceTest.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/ServiceTest.java
@@ -26,10 +26,6 @@ import org.junit.jupiter.api.TestInstance;
 
 import com.vaadin.flow.quarkus.it.service.BootstrapCustomizer;
 import com.vaadin.flow.quarkus.it.service.ServiceBean;
-import com.vaadin.flow.quarkus.it.service.ServiceView;
-import com.vaadin.flow.server.SessionDestroyEvent;
-import com.vaadin.flow.server.SessionInitEvent;
-import com.vaadin.flow.server.UIInitEvent;
 
 @QuarkusTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -69,33 +65,6 @@ public class ServiceTest extends AbstractCdiTest {
         Assertions.assertEquals(id, getText("service-id"));
         count = getCount(ServiceBean.class.getName());
         Assertions.assertEquals(1, count);
-    }
-
-    @Test
-    public void sessionInitEventObserved() throws IOException {
-        String initCounter = SessionInitEvent.class.getSimpleName();
-        assertCountEquals(0, initCounter);
-        getDriver().manage().deleteAllCookies();
-        open();
-        assertCountEquals(1, initCounter);
-    }
-
-    @Test
-    public void sessionDestroyEventObserved() throws IOException {
-        String destroyCounter = SessionDestroyEvent.class.getSimpleName();
-        assertCountEquals(0, destroyCounter);
-        open();
-        assertCountEquals(0, destroyCounter);
-        click(ServiceView.EXPIRE);
-        assertCountEquals(1, destroyCounter);
-    }
-
-    @Test
-    public void uiInitEventObserved() throws IOException {
-        String uiInitCounter = UIInitEvent.class.getSimpleName();
-        assertCountEquals(0, uiInitCounter);
-        open();
-        assertCountEquals(1, uiInitCounter);
     }
 
 }


### PR DESCRIPTION
Feature allows to listen mentioned events using @Observes methods.

fixes #21

<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

Please list all relevant dependencies in this section and provide summary of the change, motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
