### PR TITLE
test: Swap the Push to long polling

### DIFF
--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/AppShellConfig.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/AppShellConfig.java
@@ -1,8 +1,12 @@
 package com.vaadin.flow.quarkus.it;
 
 import com.vaadin.flow.component.page.AppShellConfigurator;
+import com.vaadin.flow.component.page.Push;
+import com.vaadin.flow.shared.ui.Transport;
 import com.vaadin.flow.theme.Theme;
 
 @Theme("reusable-theme")
+// TODO: Enable websockets when they are in use in Quarkus
+@Push(transport = Transport.LONG_POLLING)
 public class AppShellConfig implements AppShellConfigurator {
 }

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -114,8 +114,6 @@
                 <configuration>
                     <systemPropertyVariables>
                         <webdriver.chrome.driver>${webdriver.chrome.driver}</webdriver.chrome.driver>
-                        <!-- TODO: Enable liveReload when websockets are in use -->
-                        <vaadin.devmode.liveReload.enabled>false</vaadin.devmode.liveReload.enabled>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Description

After debug window improvements (https://github.com/vaadin/flow/pull/11980/files), the gizmo is shown even if the live reload is disabled.
Thus, it tries to use web sockets still, which causes issues in tests.
Reconfigure Push to use long polling instead.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
