### PR TITLE
chore: Update quarkus to 2.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <vaadin.flow.version>9.0-SNAPSHOT</vaadin.flow.version>
-        <quarkus.version>2.5.0.Final</quarkus.version>
+        <quarkus.version>2.5.3.Final</quarkus.version>
 
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <vaadin.flow.version>9.0-SNAPSHOT</vaadin.flow.version>
-        <quarkus.version>2.3.0.Final</quarkus.version>
+        <quarkus.version>2.5.0.Final</quarkus.version>
 
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>


### PR DESCRIPTION
Update quarkus version from 2.3.0 to 2.5.3