### PR TITLE
test: Pin guava version to avoid dependency clash

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -46,6 +46,16 @@
                 <version>${vaadin.flow.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!--
+                Guava version is pinned to avoid dependency clash between
+                quarkus bom and selenium version required by vaadin testbench
+            -->
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>31.0.1-jre</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Description

Quarkus bom explicitly defines a dependency on guava but that version clasehs with the one required by the selenium version used by vaadin testbench.

## Type of change

- [ ] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
