### PR TITLE
Skip user `VaadinServlet`s without @WebServlet instead of NPE on `quarkusBuild`

### DIFF
--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -67,6 +67,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class VaadinQuarkusProcessor {
+
     private static final Logger LOG = LoggerFactory.getLogger(VaadinQuarkusProcessor.class);
 
     private static final String FEATURE = "vaadin-quarkus";

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -63,8 +63,11 @@ import com.vaadin.quarkus.context.UIContextWrapper;
 import com.vaadin.quarkus.context.UIScopedContext;
 import com.vaadin.quarkus.context.VaadinServiceScopedContext;
 import com.vaadin.quarkus.context.VaadinSessionScopedContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class VaadinQuarkusProcessor {
+    private static final Logger LOG = LoggerFactory.getLogger(VaadinQuarkusProcessor.class);
 
     private static final String FEATURE = "vaadin-quarkus";
 
@@ -227,6 +230,11 @@ class VaadinQuarkusProcessor {
         for (ClassInfo info : vaadinServlets) {
             final AnnotationInstance webServletInstance = info.classAnnotation(
                     DotName.createSimple(WebServlet.class.getName()));
+            if (webServletInstance == null) {
+                LOG.warn("Found unexpected {} extends VaadinServlet without @WebServlet, skipping", info.name());
+                continue;
+            }
+
             String servletName = Optional
                     .ofNullable(webServletInstance.value("name"))
                     .map(AnnotationValue::asString)


### PR DESCRIPTION
## Description

If `VaadinServlet` without `@WebServlet` annotation present (like when `vaadin-cdi` happened to be in classpath) currently `quarkusBuild` will fail with NPE.

This patch skips such servlets with a warning in log.

Fixes #76

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.