### PR TITLE
test: set --host Vite flag in development mode

### DIFF
--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -118,6 +118,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <systemProperties>
+                        <vaadin.devmode.vite.options>--host</vaadin.devmode.vite.options>
+                    </systemProperties>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -126,6 +126,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <quarkus.test.arg-line>-Dvaadin.devmode.vite.options=--host</quarkus.test.arg-line>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
When running in development mode we need to add Vite --host flag
so Vite client websocket connection will work when tests are
executed on a remote browser