### PR TITLE
chore: Use open telemetry BOM to avoid version conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,8 @@
 
         <vaadin.flow.version>23.2-SNAPSHOT</vaadin.flow.version>
         <quarkus.version>2.6.0.Final</quarkus.version>
-        <open.telemetry.version>1.16.0-alpha</open.telemetry.version>
+        <open.telemetry.alpha.version>1.16.0-alpha</open.telemetry.alpha.version>
+        <open.telemetry.version>1.16.0</open.telemetry.version>
 
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>
@@ -84,13 +85,14 @@
         <dependencies>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-                <version>${open.telemetry.version}</version>
-                <scope>test</scope>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${open.telemetry.alpha.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <artifactId>opentelemetry-bom</artifactId>
                 <version>${open.telemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
         <dependencies>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+                <version>${open.telemetry.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
                 <version>${open.telemetry.version}</version>
                 <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <vaadin.flow.version>23.2-SNAPSHOT</vaadin.flow.version>
         <quarkus.version>2.6.0.Final</quarkus.version>
-        <open.telemetry.version>1.16.0-alpha</open.telemetry.version>
+        <open.telemetry.version>1.16.0</open.telemetry.version>
 
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>
@@ -84,7 +84,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <artifactId>opentelemetry-bom</artifactId>
                 <version>${open.telemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
         <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <vaadin.flow.version>23.1-SNAPSHOT</vaadin.flow.version>
+        <vaadin.flow.version>23.2-SNAPSHOT</vaadin.flow.version>
         <quarkus.version>2.6.0.Final</quarkus.version>
+        <open.telemetry.version>1.16.0-alpha</open.telemetry.version>
 
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>
@@ -81,6 +82,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
+                <version>${open.telemetry.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
         <vaadin.flow.version>23.2-SNAPSHOT</vaadin.flow.version>
         <quarkus.version>2.6.0.Final</quarkus.version>
-        <open.telemetry.version>1.16.0</open.telemetry.version>
+        <open.telemetry.version>1.16.0-alpha</open.telemetry.version>
 
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>
@@ -90,7 +90,7 @@
             </dependency>
             <dependency>
                 <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-bom</artifactId>
+                <artifactId>opentelemetry-bom-alpha</artifactId>
                 <version>${open.telemetry.version}</version>
                 <type>pom</type>
                 <scope>import</scope>


### PR DESCRIPTION
Pins open telemetry dependencies version to avoid conflicts in runtime, like
```
java.lang.NoSuchMethodError: 'io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder io.opentelemetry.sdk.autoconfigure.AutoConfiguredOpenTelemetrySdkBuilder.addTracerProviderCustomizer(java.util.function.BiFunction)'
```