### PR TITLE
fix: set load-on-startup for automatically registered Vaadin servlets

### DIFF
--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -132,7 +132,7 @@ class VaadinQuarkusProcessor {
                     .builder(QuarkusVaadinServlet.class.getName(),
                             QuarkusVaadinServlet.class.getName())
                     .addMapping("/*").setAsyncSupported(true)
-                    .setLoadOnStartup(10).build());
+                    .setLoadOnStartup(1).build());
         }
     }
 

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -17,6 +17,7 @@ package com.vaadin.quarkus.deployment;
 
 import javax.servlet.annotation.WebServlet;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
@@ -68,7 +69,8 @@ import org.slf4j.LoggerFactory;
 
 class VaadinQuarkusProcessor {
 
-    private static final Logger LOG = LoggerFactory.getLogger(VaadinQuarkusProcessor.class);
+    private static final Logger LOG = LoggerFactory
+            .getLogger(VaadinQuarkusProcessor.class);
 
     private static final String FEATURE = "vaadin-quarkus";
 
@@ -111,7 +113,7 @@ class VaadinQuarkusProcessor {
 
         // Collect all VaadinServlet instances and remove QuarkusVaadinServlet
         // and VaadinServlet from the list.
-        final Collection<ClassInfo> vaadinServlets = indexView
+        Collection<ClassInfo> vaadinServlets = indexView
                 .getAllKnownSubclasses(
                         DotName.createSimple(VaadinServlet.class.getName()))
                 .stream()
@@ -121,14 +123,16 @@ class VaadinQuarkusProcessor {
                                 .equals(VaadinServlet.class.getName()))
                 .collect(Collectors.toList());
 
-        // If no VaadinServlet instances found register QuarkusVaadinServlet
+        // Register VaadinServlet instances annotated with @WebServlet
+        vaadinServlets = registerUserServlets(servletProducer, vaadinServlets);
+        // If no annotated VaadinServlet instances is registered, register
+        // QuarkusVaadinServlet
         if (vaadinServlets.isEmpty()) {
             servletProducer.produce(ServletBuildItem
                     .builder(QuarkusVaadinServlet.class.getName(),
                             QuarkusVaadinServlet.class.getName())
-                    .addMapping("/*").setAsyncSupported(true).build());
-        } else {
-            registerUserServlets(servletProducer, vaadinServlets);
+                    .addMapping("/*").setAsyncSupported(true)
+                    .setLoadOnStartup(10).build());
         }
     }
 
@@ -224,15 +228,20 @@ class VaadinQuarkusProcessor {
                 deployment.getDeploymentManager()), 120));
     }
 
-    private void registerUserServlets(
+    private Collection<ClassInfo> registerUserServlets(
             BuildProducer<ServletBuildItem> servletProducer,
             Collection<ClassInfo> vaadinServlets) {
+        Collection<ClassInfo> registeredServlets = new ArrayList<>(
+                vaadinServlets);
         // TODO: check that we don't register 2 of the same mapping
         for (ClassInfo info : vaadinServlets) {
             final AnnotationInstance webServletInstance = info.classAnnotation(
                     DotName.createSimple(WebServlet.class.getName()));
             if (webServletInstance == null) {
-                LOG.warn("Found unexpected {} extends VaadinServlet without @WebServlet, skipping", info.name());
+                LOG.warn(
+                        "Found unexpected {} extends VaadinServlet without @WebServlet, skipping",
+                        info.name());
+                registeredServlets.remove(info);
                 continue;
             }
 
@@ -240,6 +249,9 @@ class VaadinQuarkusProcessor {
                     .ofNullable(webServletInstance.value("name"))
                     .map(AnnotationValue::asString)
                     .orElse(info.name().toString());
+            int loadOnStartup = Optional
+                    .ofNullable(webServletInstance.value("loadOnStartup"))
+                    .map(AnnotationValue::asInt).orElse(-1);
             final ServletBuildItem.Builder servletBuildItem = ServletBuildItem
                     .builder(servletName, info.name().toString());
 
@@ -251,9 +263,18 @@ class VaadinQuarkusProcessor {
 
             addWebInitParameters(webServletInstance, servletBuildItem);
             setAsyncSupportedIfDefined(webServletInstance, servletBuildItem);
-
+            servletBuildItem
+                    .setLoadOnStartup(loadOnStartup > 0 ? loadOnStartup : 1);
+            if (loadOnStartup < 1) {
+                LOG.warn(
+                        "Vaadin Servlet needs to be eagerly loaded by setting load-on-startup to be greater than 0. "
+                                + "Current value for '{}' is '{}', so it will be forced to '1'. "
+                                + "Please set 'loadOnStartup' attribute on @WebServlet annotation to a value greater than 0.",
+                        servletName, loadOnStartup);
+            }
             servletProducer.produce(servletBuildItem.build());
         }
+        return registeredServlets;
     }
 
     private void addWebInitParameters(AnnotationInstance webServletInstance,


### PR DESCRIPTION
## Description

When using Vite, DevModeInitializer blocks dev-server startup until a VaadinServlet is deployed because it needs to get the servlet path to use. If the container lazily loads servlets, Vite will not start until the first HTTP request for the Vaadin servlet is received.
This change sets load-on-startup feature for all Vaadin Servlet registered by the extension, to ensure that Vite is loaded at the startup of the Web application.
A warning message is shown for custom Vaadin servlets that do not set loadOnStartup on WebServlet annotation.

Part of vaadin/flow#14479

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
