### PR TITLE
fix: add RouterLayout as bean classes

### DIFF
--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -16,7 +16,6 @@
 package com.vaadin.quarkus.deployment;
 
 import javax.servlet.annotation.WebServlet;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -46,9 +45,12 @@ import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.vaadin.flow.router.HasErrorParameter;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.quarkus.QuarkusVaadinServlet;
 import com.vaadin.quarkus.WebsocketHttpSessionAttachRecorder;
@@ -64,8 +66,6 @@ import com.vaadin.quarkus.context.UIContextWrapper;
 import com.vaadin.quarkus.context.UIScopedContext;
 import com.vaadin.quarkus.context.VaadinServiceScopedContext;
 import com.vaadin.quarkus.context.VaadinSessionScopedContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class VaadinQuarkusProcessor {
 
@@ -92,6 +92,18 @@ class VaadinQuarkusProcessor {
         // Make and Route annotated Component a bean for injection
         additionalBeanDefiningAnnotationRegistry
                 .produce(new BeanDefiningAnnotationBuildItem(ROUTE_ANNOTATION));
+    }
+
+    @BuildStep
+    public void specifyRouterLayoutBeans(CombinedIndexBuildItem item,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer) {
+        Collection<ClassInfo> layouts = item.getComputingIndex()
+                .getAllKnownImplementors(
+                        DotName.createSimple(RouterLayout.class.getName()));
+        for (ClassInfo layoutInfo : layouts) {
+            additionalBeanProducer.produce(AdditionalBeanBuildItem
+                    .unremovableOf(layoutInfo.name().toString()));
+        }
     }
 
     @BuildStep

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/layout/LayoutWithInjection.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/layout/LayoutWithInjection.java
@@ -1,0 +1,25 @@
+package com.vaadin.flow.quarkus.it.layout;
+
+import javax.inject.Inject;
+
+import com.vaadin.flow.component.AttachEvent;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.quarkus.it.Counter;
+import com.vaadin.flow.router.RouterLayout;
+
+public class LayoutWithInjection extends Div implements RouterLayout {
+
+    public static final String LAYOUT_COUNTER_ID = "layoutCounter";
+
+    @Inject
+    Counter counter;
+
+    @Override
+    protected void onAttach(AttachEvent attachEvent) {
+        int value = counter.increment(LayoutWithInjection.class.getName());
+        Span span = new Span("Counter: " + value);
+        span.setId(LAYOUT_COUNTER_ID);
+        getElement().appendChild(span.getElement());
+    }
+}

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/layout/LayoutWithInjectionView.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/layout/LayoutWithInjectionView.java
@@ -1,0 +1,9 @@
+package com.vaadin.flow.quarkus.it.layout;
+
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.router.Route;
+
+@Route(value = "injected-layout-view", layout = LayoutWithInjection.class)
+public class LayoutWithInjectionView extends Div {
+
+}

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/LayoutWithInjectionIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/LayoutWithInjectionIT.java
@@ -1,0 +1,28 @@
+package com.vaadin.flow.quarkus.it;
+
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+import com.vaadin.flow.quarkus.it.layout.LayoutWithInjection;
+
+@QuarkusIntegrationTest
+class LayoutWithInjectionIT extends AbstractCdiIT {
+
+    @Override
+    protected String getTestPath() {
+        return "/injected-layout-view";
+    }
+
+    @Test
+    void layout_injectedComponent() {
+        open();
+        WebElement spanElement = waitUntil(driver -> driver
+                .findElement(By.id(LayoutWithInjection.LAYOUT_COUNTER_ID)));
+
+        Assertions.assertEquals("Counter: 1", spanElement.getText());
+    }
+
+}


### PR DESCRIPTION
## Description

Currently RouterLayout implementations are ignored by CDI in Quarkus This change specify RouterLayout implementors as additional bean classes to be analyzed during bean discovery.

Fixes #75

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
