### PR TITLE
fix: make sure annotated endpoints works along Vaadin PUSH

### DIFF
--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -146,9 +146,6 @@ class VaadinQuarkusProcessor {
                             QuarkusVaadinServlet.class.getName())
                     .addMapping("/*").setAsyncSupported(true)
                     .setLoadOnStartup(1)
-                    // TODO: should be fixed in Flow and removed from here
-                    .addInitParam(ApplicationConfig.JSR356_PATH_MAPPING_LENGTH,
-                            "0")
                     .build());
         }
     }
@@ -282,9 +279,6 @@ class VaadinQuarkusProcessor {
             setAsyncSupportedIfDefined(webServletInstance, servletBuildItem);
             servletBuildItem
                     .setLoadOnStartup(loadOnStartup > 0 ? loadOnStartup : 1);
-            // TODO: should be fixed in Flow and removed from here
-            servletBuildItem.addInitParam(
-                    ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
             if (loadOnStartup < 1) {
                 LOG.warn(
                         "Vaadin Servlet needs to be eagerly loaded by setting load-on-startup to be greater than 0. "

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -40,6 +40,7 @@ import io.quarkus.undertow.deployment.ServletDeploymentManagerBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.websockets.client.deployment.ServerWebSocketContainerBuildItem;
 import io.quarkus.websockets.client.deployment.WebSocketDeploymentInfoBuildItem;
+import org.atmosphere.cpr.ApplicationConfig;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
@@ -144,7 +145,11 @@ class VaadinQuarkusProcessor {
                     .builder(QuarkusVaadinServlet.class.getName(),
                             QuarkusVaadinServlet.class.getName())
                     .addMapping("/*").setAsyncSupported(true)
-                    .setLoadOnStartup(1).build());
+                    .setLoadOnStartup(1)
+                    // TODO: should be fixed in Flow and removed from here
+                    .addInitParam(ApplicationConfig.JSR356_PATH_MAPPING_LENGTH,
+                            "0")
+                    .build());
         }
     }
 
@@ -277,6 +282,9 @@ class VaadinQuarkusProcessor {
             setAsyncSupportedIfDefined(webServletInstance, servletBuildItem);
             servletBuildItem
                     .setLoadOnStartup(loadOnStartup > 0 ? loadOnStartup : 1);
+            // TODO: should be fixed in Flow and removed from here
+            servletBuildItem.addInitParam(
+                    ApplicationConfig.JSR356_PATH_MAPPING_LENGTH, "0");
             if (loadOnStartup < 1) {
                 LOG.warn(
                         "Vaadin Servlet needs to be eagerly loaded by setting load-on-startup to be greater than 0. "

--- a/integration-tests/common-test-code/pom.xml
+++ b/integration-tests/common-test-code/pom.xml
@@ -61,6 +61,12 @@
             <artifactId>flow-test-util</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>custom-websockets</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/CustomAnnotatedEnpoint.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/CustomAnnotatedEnpoint.java
@@ -1,0 +1,23 @@
+package com.vaadin.flow.quarkus.it;
+
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+
+@ServerEndpoint(CustomAnnotatedEnpoint.URI)
+public class CustomAnnotatedEnpoint {
+
+    public static final String URI = "/app-annotated-websocket";
+    public static final String PREFIX = ">> Application Annotated Endpoint: ";
+
+    @OnOpen
+    public void onOpen(Session session) {
+        session.getAsyncRemote().sendText(PREFIX + "Welcome");
+    }
+
+    @OnMessage
+    public void onMessage(String message, Session session) {
+        session.getAsyncRemote().sendText(PREFIX + message);
+    }
+}

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/CustomAnnotatedEnpoint.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/CustomAnnotatedEnpoint.java
@@ -1,9 +1,9 @@
 package com.vaadin.flow.quarkus.it;
 
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 @ServerEndpoint(CustomAnnotatedEnpoint.URI)
 public class CustomAnnotatedEnpoint {

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/CustomWebsocketsIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/CustomWebsocketsIT.java
@@ -1,18 +1,17 @@
 package com.vaadin.flow.quarkus.it;
 
-import javax.websocket.ClientEndpoint;
-import javax.websocket.ContainerProvider;
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
 import java.io.IOException;
 import java.net.URI;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
 import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.vaadin.sample.websockets.DependencyAnnotatedWS;

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/CustomWebsocketsIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/CustomWebsocketsIT.java
@@ -1,0 +1,82 @@
+package com.vaadin.flow.quarkus.it;
+
+import javax.websocket.ClientEndpoint;
+import javax.websocket.ContainerProvider;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.vaadin.sample.websockets.DependencyAnnotatedWS;
+import org.vaadin.sample.websockets.SimpleEndpoint;
+
+@QuarkusIntegrationTest
+class CustomWebsocketsIT {
+
+    @TestHTTPResource(DependencyAnnotatedWS.URI)
+    URI dependencyAnnotatedWSURI;
+
+    @TestHTTPResource(SimpleEndpoint.URI)
+    URI dependencyNotAnnotatedWSURI;
+
+    @TestHTTPResource(CustomAnnotatedEnpoint.URI)
+    URI appAnnotatedWSURI;
+
+    @Test
+    void dependencyAnnotatedEndpointShouldWork() throws Exception {
+        assertWebsocketWorks(dependencyAnnotatedWSURI,
+                DependencyAnnotatedWS.PREFIX);
+    }
+
+    @Test
+    void applicationAnnotatedEndpointShouldWork() throws Exception {
+        assertWebsocketWorks(appAnnotatedWSURI, CustomAnnotatedEnpoint.PREFIX);
+    }
+
+    @Test
+    void dependencyNotAnnotatedEndpointShouldWork() throws Exception {
+        assertWebsocketWorks(dependencyNotAnnotatedWSURI,
+                SimpleEndpoint.PREFIX);
+    }
+
+    void assertWebsocketWorks(URI uri, String messagePrefix) throws Exception {
+        Client client = new Client();
+        try (Session session = ContainerProvider.getWebSocketContainer()
+                .connectToServer(client, uri)) {
+            Assertions.assertEquals("CONNECT", client.receivedMessage());
+            Assertions.assertEquals(messagePrefix + "Welcome",
+                    client.receivedMessage());
+            session.getBasicRemote().sendText("hello world");
+            Assertions.assertEquals(messagePrefix + "hello world",
+                    client.receivedMessage());
+        }
+    }
+
+    @ClientEndpoint
+    public static class Client {
+        final LinkedBlockingDeque<String> messages = new LinkedBlockingDeque<>();
+
+        @OnOpen
+        public void open(Session session) throws IOException {
+            messages.add("CONNECT");
+        }
+
+        @OnMessage
+        void message(String msg) {
+            messages.add(msg);
+        }
+
+        String receivedMessage() throws InterruptedException {
+            return messages.poll(12, TimeUnit.SECONDS);
+        }
+
+    }
+}

--- a/integration-tests/custom-websocket-dependency/pom.xml
+++ b/integration-tests/custom-websocket-dependency/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>1.1-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -26,7 +26,14 @@
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
-            <version>1.1.2</version>
+            <version>2.1.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+            <version>2.1.0</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/integration-tests/custom-websocket-dependency/pom.xml
+++ b/integration-tests/custom-websocket-dependency/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<project
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-quarkus-integration-tests</artifactId>
+        <version>1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>custom-websockets</artifactId>
+    <name>Test dependency with custom websocket endpoints</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-api</artifactId>
+            <version>1.1.2</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jboss.jandex</groupId>
+                <artifactId>jandex-maven-plugin</artifactId>
+                <version>1.2.2</version>
+                <executions>
+                    <execution>
+                        <id>make-index</id>
+                        <goals>
+                            <goal>jandex</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/DependencyAnnotatedWS.java
+++ b/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/DependencyAnnotatedWS.java
@@ -1,0 +1,24 @@
+package org.vaadin.sample.websockets;
+
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+import java.io.IOException;
+
+@ServerEndpoint(DependencyAnnotatedWS.URI)
+public class DependencyAnnotatedWS {
+
+    public static final String URI = "/dependency-annotated-websocket";
+    public static final String PREFIX = ">> Dependency Annotated Endpoint: ";
+
+    @OnOpen
+    public void onOpen(Session session) {
+        session.getAsyncRemote().sendText(PREFIX + "Welcome");
+    }
+
+    @OnMessage
+    public void onMessage(String message, Session session) {
+        session.getAsyncRemote().sendText(PREFIX + message);
+    }
+}

--- a/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/DependencyAnnotatedWS.java
+++ b/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/DependencyAnnotatedWS.java
@@ -1,10 +1,9 @@
 package org.vaadin.sample.websockets;
 
-import javax.websocket.OnMessage;
-import javax.websocket.OnOpen;
-import javax.websocket.Session;
-import javax.websocket.server.ServerEndpoint;
-import java.io.IOException;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
 
 @ServerEndpoint(DependencyAnnotatedWS.URI)
 public class DependencyAnnotatedWS {

--- a/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpoint.java
+++ b/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpoint.java
@@ -1,0 +1,39 @@
+package org.vaadin.sample.websockets;
+
+import javax.websocket.Endpoint;
+import javax.websocket.EndpointConfig;
+import javax.websocket.MessageHandler;
+import javax.websocket.RemoteEndpoint;
+import javax.websocket.Session;
+
+public class SimpleEndpoint extends Endpoint {
+
+    public static final String URI = "/dependency-websocket";
+
+    public static final String PREFIX = ">> Dependency Simple Endpoint: ";
+
+    @Override
+    public void onOpen(Session session, EndpointConfig config) {
+        Handler handler = new Handler(session.getAsyncRemote());
+        session.addMessageHandler(handler);
+        handler.reply("Welcome");
+    }
+
+    private static class Handler implements MessageHandler.Whole<String> {
+
+        private final RemoteEndpoint.Async remote;
+
+        public Handler(RemoteEndpoint.Async remote) {
+            this.remote = remote;
+        }
+
+        @Override
+        public void onMessage(String message) {
+            reply(message);
+        }
+
+        private void reply(String message) {
+            remote.sendText(PREFIX + message);
+        }
+    }
+}

--- a/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpoint.java
+++ b/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpoint.java
@@ -1,10 +1,10 @@
 package org.vaadin.sample.websockets;
 
-import javax.websocket.Endpoint;
-import javax.websocket.EndpointConfig;
-import javax.websocket.MessageHandler;
-import javax.websocket.RemoteEndpoint;
-import javax.websocket.Session;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.EndpointConfig;
+import jakarta.websocket.MessageHandler;
+import jakarta.websocket.RemoteEndpoint;
+import jakarta.websocket.Session;
 
 public class SimpleEndpoint extends Endpoint {
 

--- a/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpointConfig.java
+++ b/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpointConfig.java
@@ -1,8 +1,8 @@
 package org.vaadin.sample.websockets;
 
-import javax.websocket.Endpoint;
-import javax.websocket.server.ServerApplicationConfig;
-import javax.websocket.server.ServerEndpointConfig;
+import jakarta.websocket.Endpoint;
+import jakarta.websocket.server.ServerApplicationConfig;
+import jakarta.websocket.server.ServerEndpointConfig;
 import java.util.Collections;
 import java.util.Set;
 

--- a/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpointConfig.java
+++ b/integration-tests/custom-websocket-dependency/src/main/java/org/vaadin/sample/websockets/SimpleEndpointConfig.java
@@ -1,0 +1,21 @@
+package org.vaadin.sample.websockets;
+
+import javax.websocket.Endpoint;
+import javax.websocket.server.ServerApplicationConfig;
+import javax.websocket.server.ServerEndpointConfig;
+import java.util.Collections;
+import java.util.Set;
+
+public class SimpleEndpointConfig implements ServerApplicationConfig {
+    @Override
+    public Set<ServerEndpointConfig> getEndpointConfigs(
+            Set<Class<? extends Endpoint>> endpointClasses) {
+        return Set.of(ServerEndpointConfig.Builder
+                .create(SimpleEndpoint.class, SimpleEndpoint.URI).build());
+    }
+
+    @Override
+    public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
+        return Collections.emptySet();
+    }
+}

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>test-addon-with-jandex</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>custom-websockets</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/integration-tests/development/vite.generated.ts
+++ b/integration-tests/development/vite.generated.ts
@@ -5,11 +5,11 @@
  * This file will be overwritten on every run. Any custom changes should be made to vite.config.ts
  */
 import path from 'path';
-import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import * as net from 'net';
 
-import { processThemeResources } from './target/plugins/application-theme-plugin/theme-handle';
-import { rewriteCssUrls } from './target/plugins/theme-loader/theme-loader-utils';
+import { processThemeResources } from './target/plugins/application-theme-plugin/theme-handle.js';
+import { rewriteCssUrls } from './target/plugins/theme-loader/theme-loader-utils.js';
 import settings from './target/vaadin-dev-server-settings.json';
 import { defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn, OutputOptions, AssetInfo, ChunkInfo } from 'vite';
 import { getManifest } from 'workbox-build';
@@ -24,10 +24,13 @@ const appShellUrl = '.';
 
 const frontendFolder = path.resolve(__dirname, settings.frontendFolder);
 const themeFolder = path.resolve(frontendFolder, settings.themeFolder);
+const statsFolder = path.resolve(__dirname, settings.statsOutput);
 const frontendBundleFolder = path.resolve(__dirname, settings.frontendBundleOutput);
-const addonFrontendFolder = path.resolve(__dirname, settings.addonFrontendFolder);
+const jarResourcesFolder = path.resolve(__dirname, settings.jarResourcesFolder);
+const generatedFlowImportsFolder = path.resolve(__dirname, settings.generatedFlowImportsFolder);
 const themeResourceFolder = path.resolve(__dirname, settings.themeResourceFolder);
-const statsFile = path.resolve(frontendBundleFolder, '..', 'config', 'stats.json');
+
+const statsFile = path.resolve(statsFolder, 'stats.json');
 
 const projectStaticAssetsFolders = [
   path.resolve(__dirname, 'src', 'main', 'resources', 'META-INF', 'resources'),
@@ -40,7 +43,7 @@ const themeProjectFolders = projectStaticAssetsFolders.map((folder) => path.reso
 
 const themeOptions = {
   devMode: false,
-  // The following matches folder 'target/flow-frontend/themes/'
+  // The following matches folder 'frontend/generated/themes/'
   // (not 'frontend/themes') for theme in JAR that is copied there
   themeResourceFolder: path.resolve(themeResourceFolder, settings.themeFolder),
   themeProjectFolders: themeProjectFolders,
@@ -182,6 +185,7 @@ function statsExtracterPlugin(): PluginOption {
         .sort()
         .filter((value, index, self) => self.indexOf(value) === index);
 
+      mkdirSync(path.dirname(statsFile), { recursive: true });
       writeFileSync(statsFile, JSON.stringify({ npmModules }, null, 1));
     }
   };
@@ -460,8 +464,7 @@ let spaMiddlewareForceRemoved = false;
 
 const allowedFrontendFolders = [
   frontendFolder,
-  addonFrontendFolder,
-  path.resolve(addonFrontendFolder, '..', 'frontend'), // Contains only generated-flow-imports
+  path.resolve(generatedFlowImportsFolder), // Contains only generated-flow-imports
   path.resolve(__dirname, 'node_modules')
 ];
 
@@ -500,6 +503,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
     base: '',
     resolve: {
       alias: {
+        '@vaadin/flow-frontend': jarResourcesFolder,
         Frontend: frontendFolder
       },
       preserveSymlinks: true
@@ -563,14 +567,14 @@ export const vaadinConfig: UserConfigFn = (env) => {
         ]
       }),
       {
-        name: 'vaadin:force-remove-spa-middleware',
+        name: 'vaadin:force-remove-html-middleware',
         transformIndexHtml: {
           enforce: 'pre',
           transform(_html, { server }) {
             if (server && !spaMiddlewareForceRemoved) {
               server.middlewares.stack = server.middlewares.stack.filter((mw) => {
                 const handleName = '' + mw.handle;
-                return !handleName.includes('viteSpaFallbackMiddleware');
+                return !handleName.includes('viteHtmlFallbackMiddleware');
               });
               spaMiddlewareForceRemoved = true;
             }

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -19,6 +19,7 @@
         <!-- Builds testing addons -->
         <module>test-addons/addon-with-jandex</module>
         <module>test-addons/addon-without-jandex</module>
+        <module>custom-websocket-dependency</module>
         <!-- only validates that code compiles -->
         <module>common-test-code</module>
 

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>test-addon-with-jandex</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>custom-websockets</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.vaadin</groupId>

--- a/integration-tests/production/vite.generated.ts
+++ b/integration-tests/production/vite.generated.ts
@@ -5,11 +5,11 @@
  * This file will be overwritten on every run. Any custom changes should be made to vite.config.ts
  */
 import path from 'path';
-import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import * as net from 'net';
 
-import { processThemeResources } from './target/plugins/application-theme-plugin/theme-handle';
-import { rewriteCssUrls } from './target/plugins/theme-loader/theme-loader-utils';
+import { processThemeResources } from './target/plugins/application-theme-plugin/theme-handle.js';
+import { rewriteCssUrls } from './target/plugins/theme-loader/theme-loader-utils.js';
 import settings from './target/vaadin-dev-server-settings.json';
 import { defineConfig, mergeConfig, PluginOption, ResolvedConfig, UserConfigFn, OutputOptions, AssetInfo, ChunkInfo } from 'vite';
 import { getManifest } from 'workbox-build';
@@ -24,10 +24,13 @@ const appShellUrl = '.';
 
 const frontendFolder = path.resolve(__dirname, settings.frontendFolder);
 const themeFolder = path.resolve(frontendFolder, settings.themeFolder);
+const statsFolder = path.resolve(__dirname, settings.statsOutput);
 const frontendBundleFolder = path.resolve(__dirname, settings.frontendBundleOutput);
-const addonFrontendFolder = path.resolve(__dirname, settings.addonFrontendFolder);
+const jarResourcesFolder = path.resolve(__dirname, settings.jarResourcesFolder);
+const generatedFlowImportsFolder = path.resolve(__dirname, settings.generatedFlowImportsFolder);
 const themeResourceFolder = path.resolve(__dirname, settings.themeResourceFolder);
-const statsFile = path.resolve(frontendBundleFolder, '..', 'config', 'stats.json');
+
+const statsFile = path.resolve(statsFolder, 'stats.json');
 
 const projectStaticAssetsFolders = [
   path.resolve(__dirname, 'src', 'main', 'resources', 'META-INF', 'resources'),
@@ -40,7 +43,7 @@ const themeProjectFolders = projectStaticAssetsFolders.map((folder) => path.reso
 
 const themeOptions = {
   devMode: false,
-  // The following matches folder 'target/flow-frontend/themes/'
+  // The following matches folder 'frontend/generated/themes/'
   // (not 'frontend/themes') for theme in JAR that is copied there
   themeResourceFolder: path.resolve(themeResourceFolder, settings.themeFolder),
   themeProjectFolders: themeProjectFolders,
@@ -182,6 +185,7 @@ function statsExtracterPlugin(): PluginOption {
         .sort()
         .filter((value, index, self) => self.indexOf(value) === index);
 
+      mkdirSync(path.dirname(statsFile), { recursive: true });
       writeFileSync(statsFile, JSON.stringify({ npmModules }, null, 1));
     }
   };
@@ -460,8 +464,7 @@ let spaMiddlewareForceRemoved = false;
 
 const allowedFrontendFolders = [
   frontendFolder,
-  addonFrontendFolder,
-  path.resolve(addonFrontendFolder, '..', 'frontend'), // Contains only generated-flow-imports
+  path.resolve(generatedFlowImportsFolder), // Contains only generated-flow-imports
   path.resolve(__dirname, 'node_modules')
 ];
 
@@ -500,6 +503,7 @@ export const vaadinConfig: UserConfigFn = (env) => {
     base: '',
     resolve: {
       alias: {
+        '@vaadin/flow-frontend': jarResourcesFolder,
         Frontend: frontendFolder
       },
       preserveSymlinks: true
@@ -563,14 +567,14 @@ export const vaadinConfig: UserConfigFn = (env) => {
         ]
       }),
       {
-        name: 'vaadin:force-remove-spa-middleware',
+        name: 'vaadin:force-remove-html-middleware',
         transformIndexHtml: {
           enforce: 'pre',
           transform(_html, { server }) {
             if (server && !spaMiddlewareForceRemoved) {
               server.middlewares.stack = server.middlewares.stack.filter((mw) => {
                 const handleName = '' + mw.handle;
-                return !handleName.includes('viteSpaFallbackMiddleware');
+                return !handleName.includes('viteHtmlFallbackMiddleware');
               });
               spaMiddlewareForceRemoved = true;
             }

--- a/runtime/src/main/java/com/vaadin/quarkus/EnableWebsockets.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/EnableWebsockets.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * deployment, in order to make Atmosphere JSR365Endpoint work.
  * 
  * Quarkus enables WebSocket deployment only if it finds annotated endpoints
- * (@{@link javax.websocket.server.ServerEndpoint}) or implementors of
+ * (@{@link jakarta.websocket.server.ServerEndpoint}) or implementors of
  * {@link ServerApplicationConfig} interface.
  * 
  * Unfortunately, if at least one implementation of

--- a/runtime/src/main/java/com/vaadin/quarkus/EnableWebsockets.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/EnableWebsockets.java
@@ -19,22 +19,39 @@ import jakarta.websocket.Endpoint;
 import jakarta.websocket.server.ServerApplicationConfig;
 import jakarta.websocket.server.ServerEndpointConfig;
 
+import java.util.Collections;
 import java.util.Set;
 
 /**
  * Only purpose of this class is to automatically enable quarkus WebSocket
  * deployment, in order to make Atmosphere JSR365Endpoint work.
+ * 
+ * Quarkus enables WebSocket deployment only if it finds annotated endpoints
+ * (@{@link javax.websocket.server.ServerEndpoint}) or implementors of
+ * {@link ServerApplicationConfig} interface.
+ * 
+ * Unfortunately, if at least one implementation of
+ * {@link ServerApplicationConfig} is found, annotated endpoints are not
+ * deployed automatically.
+ *
+ * To circumvent this problem, implementation of
+ * {@link #getAnnotatedEndpointClasses(Set)} method will return all the provided
+ * scanned annotated endpoints. Although Javadocs says that the passed set of
+ * scanned classes contains all the annotated endpoint classes in the JAR or WAR
+ * file containing the implementation of this interface, Quarkus will instead
+ * provide all available annotated endpoints found at build time.
+ *
  */
 public class EnableWebsockets implements ServerApplicationConfig {
 
     @Override
     public Set<ServerEndpointConfig> getEndpointConfigs(
             Set<Class<? extends Endpoint>> endpointClasses) {
-        return null;
+        return Collections.emptySet();
     }
 
     @Override
     public Set<Class<?>> getAnnotatedEndpointClasses(Set<Class<?>> scanned) {
-        return null;
+        return scanned;
     }
 }


### PR DESCRIPTION
## Description

The workaround added to make PUSH work in Quarkus prevents the usage of custom annotated websocket endpoint. This change allows them to work along Vaadin PUSH.

Fixes #78

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
