### PR TITLE
fix: updates after removal of deprecated Flow code

### DIFF
--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -128,19 +128,9 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <systemProperties>
-                        <vaadin.devmode.vite.options>--host</vaadin.devmode.vite.options>
-                    </systemProperties>
-                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <quarkus.test.arg-line>-Dvaadin.devmode.vite.options=--host</quarkus.test.arg-line>
-                    </systemPropertyVariables>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -112,7 +112,6 @@
                     <execution>
                         <goals>
                             <goal>prepare-frontend</goal>
-                            <goal>build-frontend</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -112,6 +112,7 @@
                     <execution>
                         <goals>
                             <goal>prepare-frontend</goal>
+                            <goal>build-frontend</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
@@ -15,13 +15,10 @@
  */
 package com.vaadin.quarkus;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.inject.Inject;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-import io.quarkus.arc.Unremovable;
+import jakarta.enterprise.inject.spi.BeanManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,25 +26,8 @@ import com.vaadin.flow.component.Component;
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.server.VaadinService;
 import com.vaadin.flow.server.VaadinServiceInitListener;
-import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
 
-/**
- * Instantiator implementation based on Quarkus DI feature.
- *
- * Quarkus DI solution (also called ArC) is based on the Contexts and Dependency
- * Injection for Java 2.0 specification, but it is not a full CDI
- * implementation. Only a subset of the CDI features is implemented.
- *
- * See <a href="https://quarkus.io/guides/cdi-reference">Quarkus CDI
- * Reference</a> for further details.
- *
- * @see Instantiator
- */
-@VaadinServiceEnabled
-@Unremovable
-@ApplicationScoped
 public class QuarkusInstantiator implements Instantiator {
 
     private static final String CANNOT_USE_CDI_BEANS_FOR_I18N = "Cannot use CDI beans for I18N, falling back to the default behavior.";
@@ -56,16 +36,12 @@ public class QuarkusInstantiator implements Instantiator {
     private AtomicBoolean i18NLoggingEnabled = new AtomicBoolean(true);
     private DefaultInstantiator delegate;
 
-    @Inject
-    BeanManager beanManager;
+    private BeanManager beanManager;
 
-    /**
-     * Gets the service class that this instantiator is supposed to work with.
-     *
-     * @return the service class this instantiator is supposed to work with.
-     */
-    public Class<? extends VaadinService> getServiceClass() {
-        return QuarkusVaadinServletService.class;
+    public QuarkusInstantiator(DefaultInstantiator delegate,
+            BeanManager beanManager) {
+        this.delegate = delegate;
+        this.beanManager = beanManager;
     }
 
     /**
@@ -75,13 +51,6 @@ public class QuarkusInstantiator implements Instantiator {
      */
     public BeanManager getBeanManager() {
         return this.beanManager;
-    }
-
-    @Override
-    public boolean init(final VaadinService service) {
-        delegate = new DefaultInstantiator(service);
-        return delegate.init(service)
-                && getServiceClass().isAssignableFrom(service.getClass());
     }
 
     @Override

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
@@ -25,9 +25,17 @@ import org.slf4j.LoggerFactory;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.di.DefaultInstantiator;
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 
+/**
+ * Instantiator implementation for Quarkus.
+ *
+ * New instances are created by default by QuarkusInstantiatorFactory.
+ *
+ * @see InstantiatorFactory
+ */
 public class QuarkusInstantiator implements Instantiator {
 
     private static final String CANNOT_USE_CDI_BEANS_FOR_I18N = "Cannot use CDI beans for I18N, falling back to the default behavior.";

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiatorFactory.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiatorFactory.java
@@ -1,0 +1,54 @@
+package com.vaadin.quarkus;
+
+import io.quarkus.arc.Unremovable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+
+import com.vaadin.flow.di.DefaultInstantiator;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
+
+/**
+ * Instantiator factory implementation based on Quarkus DI feature.
+ *
+ * Quarkus DI solution (also called ArC) is based on the Contexts and Dependency
+ * Injection for Java 2.0 specification, but it is not a full CDI
+ * implementation. Only a subset of the CDI features is implemented.
+ *
+ * See <a href="https://quarkus.io/guides/cdi-reference">Quarkus CDI
+ * Reference</a> for further details.
+ *
+ * @see InstantiatorFactory
+ */
+@VaadinServiceEnabled
+@Unremovable
+@ApplicationScoped
+public class QuarkusInstantiatorFactory implements InstantiatorFactory {
+
+    @Inject
+    BeanManager beanManager;
+
+    @Override
+    public Instantiator createInstantitor(VaadinService vaadinService) {
+        if (!getServiceClass().isAssignableFrom(vaadinService.getClass())) {
+            return null;
+        }
+        return new QuarkusInstantiator(new DefaultInstantiator(vaadinService),
+                beanManager);
+    }
+
+    /**
+     * Gets the service class that this instantiator factory is supposed to work
+     * with.
+     *
+     * @return the service class this instantiator factory is supposed to work
+     *         with.
+     */
+    public Class<? extends VaadinService> getServiceClass() {
+        return QuarkusVaadinServletService.class;
+    }
+
+}

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServletService.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServletService.java
@@ -33,6 +33,7 @@ import com.vaadin.flow.component.ComponentEventListener;
 import com.vaadin.flow.component.PollEvent;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.di.InstantiatorFactory;
 import com.vaadin.flow.function.DeploymentConfiguration;
 import com.vaadin.flow.internal.UsageStatistics;
 import com.vaadin.flow.router.AfterNavigationEvent;
@@ -103,10 +104,10 @@ public class QuarkusVaadinServletService extends VaadinServletService {
             throw new ServiceException("Cannot init VaadinService "
                     + "because no CDI instantiator bean found.");
         }
-        final Bean<Instantiator> bean;
+        final Bean<InstantiatorFactory> bean;
         try {
             // noinspection unchecked
-            bean = (Bean<Instantiator>) beanManager.resolve(beans);
+            bean = (Bean<InstantiatorFactory>) beanManager.resolve(beans);
         } catch (final AmbiguousResolutionException e) {
             throw new ServiceException(
                     "There are multiple eligible CDI "
@@ -118,12 +119,14 @@ public class QuarkusVaadinServletService extends VaadinServletService {
         // stored inside VaadinService. Not relying on the proxy allows
         // accessing VaadinService::getInstantiator even when
         // VaadinServiceScopedContext is not active
-        final CreationalContext<Instantiator> creationalContext = beanManager
+        final CreationalContext<InstantiatorFactory> creationalContext = beanManager
                 .createCreationalContext(bean);
         final Context context = beanManager.getContext(ApplicationScoped.class); // VaadinServiceScoped
-        final Instantiator instantiator = context.get(bean, creationalContext);
+        final InstantiatorFactory instantiatorFactory = context.get(bean,
+                creationalContext);
 
-        if (!instantiator.init(this)) {
+        Instantiator instantiator = instantiatorFactory.createInstantitor(this);
+        if (instantiator == null) {
             throw new ServiceException("Cannot init VaadinService because "
                     + instantiator.getClass().getName() + " CDI bean init()"
                     + " returned false.");

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServletService.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServletService.java
@@ -102,7 +102,7 @@ public class QuarkusVaadinServletService extends VaadinServletService {
                 BeanLookup.SERVICE);
         if (beans == null || beans.isEmpty()) {
             throw new ServiceException("Cannot init VaadinService "
-                    + "because no CDI instantiator bean found.");
+                    + "because no CDI instantiator factory bean found.");
         }
         final Bean<InstantiatorFactory> bean;
         try {
@@ -111,7 +111,7 @@ public class QuarkusVaadinServletService extends VaadinServletService {
         } catch (final AmbiguousResolutionException e) {
             throw new ServiceException(
                     "There are multiple eligible CDI "
-                            + Instantiator.class.getSimpleName() + " beans.",
+                            + InstantiatorFactory.class.getSimpleName() + " beans.",
                     e);
         }
 
@@ -128,8 +128,7 @@ public class QuarkusVaadinServletService extends VaadinServletService {
         Instantiator instantiator = instantiatorFactory.createInstantitor(this);
         if (instantiator == null) {
             throw new ServiceException("Cannot init VaadinService because "
-                    + instantiator.getClass().getName() + " CDI bean init()"
-                    + " returned false.");
+                    + Instantiator.class.getSimpleName() + " is null");
         }
         return Optional.of(instantiator);
     }

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServletService.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServletService.java
@@ -98,7 +98,7 @@ public class QuarkusVaadinServletService extends VaadinServletService {
 
     @Override
     public Optional<Instantiator> loadInstantiators() throws ServiceException {
-        final Set<Bean<?>> beans = beanManager.getBeans(Instantiator.class,
+        final Set<Bean<?>> beans = beanManager.getBeans(InstantiatorFactory.class,
                 BeanLookup.SERVICE);
         if (beans == null || beans.isEmpty()) {
             throw new ServiceException("Cannot init VaadinService "

--- a/runtime/src/main/java/com/vaadin/quarkus/annotation/VaadinServiceEnabled.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/annotation/VaadinServiceEnabled.java
@@ -31,7 +31,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Qualifier to mark Vaadin service implementations.
  *
  * Qualified CDI beans implementing {@link com.vaadin.flow.i18n.I18NProvider},
- * and {@link com.vaadin.flow.di.Instantiator} interfaces are loaded.
+ * and {@link com.vaadin.flow.di.InstantiatorFactory} interfaces are loaded.
  */
 @Qualifier
 @Retention(RUNTIME)


### PR DESCRIPTION
Replaced `Instantiator.init()` with `InstantiatorFactory`