### PR TITLE
chore: update to quarkus 3 final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <vaadin.flow.version>24.0-SNAPSHOT</vaadin.flow.version>
-        <quarkus.version>3.0.0.Alpha4</quarkus.version>
+        <quarkus.version>3.0.1.Final</quarkus.version>
         <open.telemetry.alpha.version>1.16.0-alpha</open.telemetry.alpha.version>
         <open.telemetry.version>1.16.0</open.telemetry.version>
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -66,7 +66,7 @@
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
         <version>${quarkus.version}</version>
         <executions>
           <execution>


### PR DESCRIPTION
Updated project to use Quarkus 3 final version and replaced the removed quarkus-bootstrap-maven-plugin, as documented in the migration guide.