### PR TITLE
test: fixed quarkus websocket artifact

### DIFF
--- a/integration-tests/common-test-code/pom.xml
+++ b/integration-tests/common-test-code/pom.xml
@@ -36,7 +36,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow-websockets</artifactId>
+            <artifactId>quarkus-websockets</artifactId>
         </dependency>
 
         <dependency>

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -68,7 +68,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow-websockets</artifactId>
+            <artifactId>quarkus-websockets</artifactId>
         </dependency>
 
         <!-- Test dependencies -->

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -63,7 +63,7 @@
 
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-undertow-websockets</artifactId>
+            <artifactId>quarkus-websockets</artifactId>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
quarkus-undertow-websockets has been removed since Quarkus 2.8.
Replacement is quarkus-websockets.
