### PR TITLE
test: override ContextualStorageManager in UiContextTest

### DIFF
--- a/runtime/src/test/java/com/vaadin/quarkus/context/UiContextTest.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/context/UiContextTest.java
@@ -16,7 +16,9 @@
 
 package com.vaadin.quarkus.context;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import java.lang.reflect.Proxy;
@@ -55,6 +57,8 @@ public class UiContextTest extends AbstractContextTest<TestUIScopedContext> {
 
     @Dependent
     @Unremovable
+    @Alternative
+    @Priority(1)
     public static class TestContextualStorageManager
             extends UIScopedContext.ContextualStorageManager {
 


### PR DESCRIPTION
## Description

Since latest changes in Quarkus, scope annotated beans are discovered even if the scope is not registered.
This change marks the ContextualStorageManager used in UiContextTest as an alternative to the VaadinSessionScoped ContextualStorageManager bean defined in UIScopedContext, preventing AmbiguousResolutionException in tests.

Fixes #131

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
