### PR TITLE
test: retry count assertion on session invalidation

### DIFF
--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/AbstractCdiIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/AbstractCdiIT.java
@@ -41,6 +41,17 @@ abstract public class AbstractCdiIT extends AbstractChromeIT {
         return findElement(By.id(id)).getText();
     }
 
+    protected void waitForCount(int expectedCount, String counter) {
+        waitUntil(driver -> {
+            try {
+                assertCountEquals(expectedCount, counter);
+                return true;
+            } catch (Exception ex) {
+                return false;
+            }
+        }, 1);
+    }
+
     protected void assertCountEquals(int expectedCount, String counter)
             throws IOException {
         Assert.assertEquals(expectedCount, getCount(counter));

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/SessionContextCloseIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/SessionContextCloseIT.java
@@ -48,6 +48,6 @@ public class SessionContextCloseIT extends AbstractCdiIT {
 
     private void assertDestroyCountEquals(int expectedCount)
             throws IOException {
-        assertCountEquals(expectedCount, DESTROY_COUNT);
+        waitForCount(expectedCount, DESTROY_COUNT);
     }
 }

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/SessionContextIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/SessionContextIT.java
@@ -83,7 +83,7 @@ public class SessionContextIT extends AbstractCdiIT {
 
     private void assertDestroyCountEquals(int expectedCount)
             throws IOException {
-        assertCountEquals(expectedCount, DESTROY_COUNT);
+        waitForCount(expectedCount, DESTROY_COUNT);
     }
 
     private static Logger getLogger() {


### PR DESCRIPTION
## Description

Session context tests check the counter value hold by a session bean right after invalidating the Vaadin session. Since the counter is incremented in the PreDestroy hook, it may happen that when the test checks for the counter value, the callback has not yet been invoked. This change retries the counter check for at most on second, to preven ttest flakyness.

Fixes #126

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
