### PR TITLE
test: allow remote connection to debug window

### DIFF
--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/test/AbstractChromeIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/test/AbstractChromeIT.java
@@ -3,6 +3,12 @@ package com.vaadin.flow.test;
 import java.util.Arrays;
 import java.util.List;
 
+import com.vaadin.flow.testcategory.ChromeTests;
+import com.vaadin.flow.testutil.ChromeBrowserTest;
+import com.vaadin.testbench.annotations.BrowserConfiguration;
+import com.vaadin.testbench.parallel.Browser;
+import com.vaadin.testbench.parallel.BrowserUtil;
+import io.quarkus.test.common.QuarkusTestResource;
 import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,19 +17,14 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
-import com.vaadin.flow.testcategory.ChromeTests;
-import com.vaadin.flow.testutil.ChromeBrowserTest;
-import com.vaadin.testbench.annotations.BrowserConfiguration;
-import com.vaadin.testbench.parallel.Browser;
-import com.vaadin.testbench.parallel.BrowserUtil;
-
 /**
  * Simplified chrome test that doesn't handle view/IT class paths. Uses Jupiter
  * API
  */
 @Category(ChromeTests.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(ScreenshotsOnFailureExtension.class)
+@ExtendWith({ ScreenshotsOnFailureExtension.class })
+@QuarkusTestResource(VaadinSystemPropertiesPropagator.class)
 public abstract class AbstractChromeIT extends ChromeBrowserTest {
 
     @AfterEach

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/test/VaadinSystemPropertiesPropagator.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/test/VaadinSystemPropertiesPropagator.java
@@ -1,0 +1,26 @@
+package com.vaadin.flow.test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+
+/**
+ * Propagates all Vaadin related system properties to Quarkus test.
+ */
+public class VaadinSystemPropertiesPropagator
+        implements QuarkusTestResourceLifecycleManager {
+
+    @Override
+    public Map<String, String> start() {
+        Map<String, String> props = new HashMap<>();
+        System.getProperties().stringPropertyNames().stream()
+                .filter(key -> key.startsWith("vaadin."))
+                .forEach(key -> props.put(key, System.getProperty(key)));
+        return props;
+    }
+
+    @Override
+    public void stop() {
+    }
+}

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -131,6 +131,11 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <vaadin.devmode.hostsAllowed>*</vaadin.devmode.hostsAllowed>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Prevents debug window access denied error logs on browser console that make some tests fail