### PR TITLE
test: reset UI poll interval in UI.access block

### DIFF
--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/i18n/TranslationView.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/i18n/TranslationView.java
@@ -84,9 +84,11 @@ public class TranslationView extends Div {
             } catch (Exception e) {
                 e.printStackTrace();
             } finally {
-                ui.access(() -> dynamic
-                        .setText(getTranslation("label", Locale.FRANCE)));
-                ui.setPollInterval(-1);
+                ui.access(() -> {
+                    dynamic.setText(getTranslation("label", Locale.FRANCE));
+                    ui.setPollInterval(-1);
+                });
+
             }
         });
 


### PR DESCRIPTION
Resets the poll interval in the UI.access block so that the change is immediately pushed to the client and polling is stopped. Otherwise, the client will continue to poll until a UIDL request is sent the server.
