### PR TITLE
chore: pin JNA version to prevent wrong management

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -60,6 +60,19 @@
                 <version>31.0.1-jre</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- Pin JNA version to prevent clashes between Vaadin License Checker and Quarkus BOM -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>5.14.0</version>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>5.14.0</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,16 +102,16 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-bom</artifactId>
+                <version>${vaadin.flow.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-bom</artifactId>
-                <version>${vaadin.flow.version}</version>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Quarkus BOM declares JNA dependencies in a version older than the one
required by Vaadin License Checker.
Swapping Flow and Quarkus BOMs does not help because JNA is a transitive
dependency of license checker and Quarkus BOM wins becuase its
definition is nearest to the root of the dependency tree.
Pin JNA in the parent integration tests module fixes the issue.