### PR TITLE
chore: bump Quarkus to 3.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,11 +35,11 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <vaadin.flow.version>24.4-SNAPSHOT</vaadin.flow.version>
-        <quarkus.version>3.0.1.Final</quarkus.version>
+        <quarkus.version>3.8.4</quarkus.version>
         <open.telemetry.alpha.version>1.16.0-alpha</open.telemetry.alpha.version>
         <open.telemetry.version>1.16.0</open.telemetry.version>
 
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+        <surefire-plugin.version>3.2.5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>
     </properties>
 


### PR DESCRIPTION
Quarkus 3.8 is the latest LTS.