### PR TITLE
chore: improve extension metadata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,12 @@
     <packaging>pom</packaging>
 
     <name>Vaadin Quarkus - Parent</name>
+    <scm>
+        <connection>scm:git:git@github.com:vaadin/quarkus.git</connection>
+        <developerConnection>scm:git:git@github.com:vaadin/quarkus.git</developerConnection>
+        <url>https://github.com/vaadin/quarkus</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <modules>
         <module>deployment</module>

--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,6 +6,7 @@ metadata:
     - flow
     - web
   guide: "https://vaadin.com/docs/latest/flow/integrations/quarkus"
+  icon-url: "https://vaadin.com/images/trademark/PNG/VaadinLogomark_RGB_500x500.png"
   categories:
     - "web"
   status: "stable"


### PR DESCRIPTION
Adds SCM info and link to Vaadin logo to the extension metadata to be shown on https://quarkus.io/extensions.

Fixes #162