### PR TITLE
fix: index optional dependencies

### DIFF
--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -32,6 +32,14 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-dnd</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-react</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
 

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -32,6 +32,14 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-dnd</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-react</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>reusable-theme</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
Development (e.g. vaadin-dev-server) and optional (e.g. flow-react) dependencies must not be present in the Vaadin platform indexed, to prevent NoClassDefFound errors at runtime, for example when running a production build with dev-server excluded.
This change adds a build step to index optional dependencies only if they are present in the project configuration.

Part of #158