### PR TITLE
fix: index optional dependencies (#172) (CP: 2.0)

### DIFF
--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -32,6 +32,14 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-dnd</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-react</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -60,6 +60,20 @@
                 <version>31.0.1-jre</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- Pin JNA version to prevent clashes between Vaadin License Checker and Quarkus BOM -->
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna</artifactId>
+                <version>5.14.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.java.dev.jna</groupId>
+                <artifactId>jna-platform</artifactId>
+                <version>5.14.0</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -32,6 +32,14 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
+            <artifactId>flow-dnd</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-react</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
             <artifactId>reusable-theme</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
         <vaadin.flow.version>24.4-SNAPSHOT</vaadin.flow.version>
-        <quarkus.version>3.0.1.Final</quarkus.version>
+        <quarkus.version>3.2.12.Final</quarkus.version>
         <open.telemetry.alpha.version>1.16.0-alpha</open.telemetry.alpha.version>
         <open.telemetry.version>1.16.0</open.telemetry.version>
 
@@ -102,16 +102,16 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-bom</artifactId>
-                <version>${quarkus.version}</version>
+                <groupId>com.vaadin</groupId>
+                <artifactId>flow-bom</artifactId>
+                <version>${vaadin.flow.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>com.vaadin</groupId>
-                <artifactId>flow-bom</artifactId>
-                <version>${vaadin.flow.version}</version>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-bom</artifactId>
+                <version>${quarkus.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Development (e.g. vaadin-dev-server) and optional (e.g. flow-react) dependencies must not be present in the Vaadin platform indexed, to prevent NoClassDefFound errors at runtime, for example when running a production build with dev-server excluded.
This change adds a build step to index optional dependencies only if they are present in the project configuration.

Part of #158
