### PR TITLE
test: allow to exclude flow-react for 24.3 tests (2.0)

### DIFF
--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -36,10 +36,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-react</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>vaadin-dev-server</artifactId>
         </dependency>
 
@@ -223,6 +219,25 @@
                     </plugins>
                 </pluginManagement>
             </build>
+        </profile>
+        <!--
+            2.0 version of the addon targets  Vaadin [24,24.5), but flow-react was
+            introduced in 24.4. This profile allows to exclude the dependency by
+            setting the -Dvaadin.exclude-flow-react system property
+        -->
+        <profile>
+            <id>add-flow-react-dependency</id>
+            <activation>
+                <property>
+                    <name>!vaadin.exclude-flow-react</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-react</artifactId>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -36,10 +36,6 @@
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
-            <artifactId>flow-react</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.vaadin</groupId>
             <artifactId>reusable-theme</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -142,5 +138,22 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>add-flow-react-dependency</id>
+            <activation>
+                <property>
+                    <name>!vaadin.exclude-flow-react</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>flow-react</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
The flow-react artifact has been added in Flow 24.4. This change makes it possible to exclude it for
previous Flow versions by setting the vaadin.exclude-flow-react system property.
