### PR TITLE
fix: provide default MenuAccessControl instance

### DIFF
--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
@@ -28,6 +28,7 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.di.InstantiatorFactory;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 
 /**
  * Instantiator implementation for Quarkus.
@@ -100,6 +101,13 @@ public class QuarkusInstantiator implements Instantiator {
             });
         }
         return lookup.lookupOrElseGet(delegate::getI18NProvider);
+    }
+
+    @Override
+    public MenuAccessControl getMenuAccessControl() {
+        final BeanLookup<MenuAccessControl> lookup = new BeanLookup<>(
+                getBeanManager(), MenuAccessControl.class, BeanLookup.SERVICE);
+        return lookup.lookupOrElseGet(delegate::getMenuAccessControl);
     }
 
     private static Logger getLogger() {

--- a/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorDefaultsTest.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorDefaultsTest.java
@@ -1,0 +1,73 @@
+package com.vaadin.quarkus;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
+import com.vaadin.flow.server.auth.MenuAccessControl;
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
+import com.vaadin.quarkus.context.ServiceUnderTestContext;
+
+@QuarkusTest
+@TestProfile(QuarkusInstantiatorDefaultsTest.NoBeansTestProfile.class)
+class QuarkusInstantiatorDefaultsTest {
+
+    @Inject
+    BeanManager beanManager;
+
+    @Inject
+    @VaadinServiceEnabled
+    QuarkusInstantiatorFactory instantiatorFactory;
+
+    Instantiator instantiator;
+
+    ServiceUnderTestContext serviceUnderTestContext;
+
+    @BeforeEach
+    public void setUp() {
+        serviceUnderTestContext = new ServiceUnderTestContext(beanManager);
+        serviceUnderTestContext.activate();
+        instantiator = instantiatorFactory
+                .createInstantitor(VaadinService.getCurrent());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        serviceUnderTestContext.tearDownAll();
+    }
+
+    @Test
+    public void getMenuAccessControl_beanNotProvided_instanceReturned() {
+        MenuAccessControl menuAccessControl = instantiator
+                .getMenuAccessControl();
+        Assertions.assertNotNull(menuAccessControl);
+        Assertions.assertTrue(
+                menuAccessControl instanceof DefaultMenuAccessControl);
+    }
+
+    public static class NoBeansTestProfile implements QuarkusTestProfile {
+        @Override
+        public String getConfigProfile() {
+            return "empty";
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            // Prevents discovering beans defined in QuarkusInstantiatorTest
+            return Map.of("quarkus.arc.exclude-types",
+                    QuarkusInstantiatorTest.TestMenuAccessControl.class
+                            .getName());
+        }
+    }
+}

--- a/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorTest.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorTest.java
@@ -185,7 +185,7 @@ public class QuarkusInstantiatorTest {
     }
 
     @Test
-    public void getMenuAccessControl_beanNotProvided_instanceReturned() {
+    public void getMenuAccessControl_beanProvided_instanceReturned() {
         MenuAccessControl menuAccessControl = instantiator
                 .getMenuAccessControl();
         Assertions.assertNotNull(menuAccessControl);

--- a/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorTest.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorTest.java
@@ -24,6 +24,8 @@ import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.server.ServiceInitEvent;
 import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.auth.DefaultMenuAccessControl;
+import com.vaadin.flow.server.auth.MenuAccessControl;
 import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
 import com.vaadin.quarkus.context.ServiceUnderTestContext;
 import io.quarkus.test.junit.QuarkusTest;
@@ -114,6 +116,22 @@ public class QuarkusInstantiatorTest {
 
     }
 
+    @VaadinServiceEnabled
+    @Singleton
+    public static class TestMenuAccessControl implements MenuAccessControl {
+
+        @Override
+        public void setPopulateClientSideMenu(
+                PopulateClientMenu populateClientSideMenu) {
+
+        }
+
+        @Override
+        public PopulateClientMenu getPopulateClientSideMenu() {
+            return null;
+        }
+    }
+
     @Singleton
     public static class ServiceInitObserver {
 
@@ -164,6 +182,15 @@ public class QuarkusInstantiatorTest {
         I18NProvider i18NProvider = instantiator.getI18NProvider();
         Assertions.assertNotNull(i18NProvider);
         Assertions.assertTrue(i18NProvider instanceof I18NTestProvider);
+    }
+
+    @Test
+    public void getMenuAccessControl_beanNotProvided_instanceReturned() {
+        MenuAccessControl menuAccessControl = instantiator
+                .getMenuAccessControl();
+        Assertions.assertNotNull(menuAccessControl);
+        Assertions
+                .assertTrue(menuAccessControl instanceof TestMenuAccessControl);
     }
 
     /*


### PR DESCRIPTION
A MenuAccessControl instance is required when operating with MenuConfiguration. This change provides a default implementation if the user project does not define a specialized bean.

Fixes #175