### PR TITLE
test: wait for system messages notification

### DIFF
--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/ServiceIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/ServiceIT.java
@@ -115,8 +115,8 @@ public class ServiceIT extends AbstractCdiIT {
     }
 
     private void assertSystemMessageEquals(String expected) {
-        WebElement message = findElement(
-                By.cssSelector("div.v-system-error div.message"));
+        WebElement message = waitUntil(d -> findElement(
+                By.cssSelector("div.v-system-error div.message")));
         Assertions.assertEquals(expected, message.getText());
     }
 


### PR DESCRIPTION
Flow client introduced a little delay in session expiration handling to prevent issues with slow connections.
This change makes the test wait for notification to be shown before asserting on text message.