### PR TITLE
chore: bump Flow to 23.5 in quarkus ecosystem workflow

### DIFF
--- a/.github/workflows/quarkus-snapshot.yaml
+++ b/.github/workflows/quarkus-snapshot.yaml
@@ -72,8 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'quarkusbot' || github.event_name == 'workflow_dispatch'
     env:
-      JAVA_VERSION: 11
-      FLOW_VERSION: 23.3-SNAPSHOT
+      FLOW_VERSION: 23.5-SNAPSHOT
     steps:
       - name: Install yq
         uses: dcarbone/install-yq-action@v1.0.1


### PR DESCRIPTION
Also runs with Java 17 to prevent build failures because of issue update script using Java records.
