### PR TITLE
chore: bump project to 2.2 and Vaadin to 24.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # vaadin-quarkus
 An extension to Quarkus to support Vaadin Flow.
 
-Supports Quarkus 3.15+
+Supports Quarkus 3.20+
 
 To try it out, you can get a project https://github.com/vaadin/base-starter-flow-quarkus/
 
-This branch is compatible with upcoming Vaadin 24 platform versions and uses Quarkus 3.15 (LTS). See other branches for other Vaadin versions:
+This branch is compatible with upcoming Vaadin 24.8+ platform versions and uses Quarkus 3.20 (LTS). See other branches for other Vaadin versions:
 
+* 2.1 for Vaadin 24 and Quarkus 3.15
 * 1.1 for Vaadin 23 and Quarkus 2
 
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-parent</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-buildtools</artifactId>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-deployment</artifactId>

--- a/integration-tests/codestarts/pom.xml
+++ b/integration-tests/codestarts/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-codestarts-tests</artifactId>

--- a/integration-tests/common-test-code/pom.xml
+++ b/integration-tests/common-test-code/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-common-test-code</artifactId>
@@ -86,7 +86,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
                 <configuration>
                     <skipTests>true</skipTests>
                 </configuration>

--- a/integration-tests/custom-websocket-dependency/pom.xml
+++ b/integration-tests/custom-websocket-dependency/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -40,9 +40,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.2</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-development-tests</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
@@ -57,11 +57,12 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>31.0.1-jre</version>
+                <version>33.4.8-jre</version>
                 <scope>test</scope>
             </dependency>
 
-            <!-- Pin JNA version to prevent clashes between Vaadin License Checker and Quarkus BOM -->
+            <!-- Uncomment to pin JNA version to prevent clashes between Vaadin License Checker and Quarkus BOM -->
+            <!--
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
@@ -72,7 +73,7 @@
                 <artifactId>jna-platform</artifactId>
                 <version>5.14.0</version>
             </dependency>
-
+            -->
         </dependencies>
     </dependencyManagement>
 
@@ -80,7 +81,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-production-tests</artifactId>

--- a/integration-tests/reusable-theme/pom.xml
+++ b/integration-tests/reusable-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -16,7 +16,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <vaadin-lumo-theme.version>24.5-SNAPSHOT</vaadin-lumo-theme.version>
+        <vaadin-lumo-theme.version>24.8-SNAPSHOT</vaadin-lumo-theme.version>
     </properties>
 
     <dependencies>

--- a/integration-tests/test-addons/addon-with-jandex/pom.xml
+++ b/integration-tests/test-addons/addon-with-jandex/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -58,9 +58,9 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.jboss.jandex</groupId>
+                <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>1.2.2</version>
+                <version>3.2.7</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/integration-tests/test-addons/addon-without-jandex/pom.xml
+++ b/integration-tests/test-addons/addon-without-jandex/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-parent</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Vaadin Quarkus - Parent</name>
@@ -36,16 +36,16 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
+        <compiler-plugin.version>3.14.0</compiler-plugin.version>
+        <surefire-plugin.version>3.5.3</surefire-plugin.version>
         <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <vaadin.flow.version>24.7-SNAPSHOT</vaadin.flow.version>
-        <quarkus.version>3.15.3</quarkus.version>
+        <vaadin.flow.version>24.8-SNAPSHOT</vaadin.flow.version>
+        <quarkus.version>3.20.1</quarkus.version>
         <open.telemetry.alpha.version>1.16.0-alpha</open.telemetry.alpha.version>
         <open.telemetry.version>1.16.0</open.telemetry.version>
 
-        <surefire-plugin.version>3.2.5</surefire-plugin.version>
         <surefire.excludedGroups>slow</surefire.excludedGroups>
     </properties>
 
@@ -89,20 +89,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-bom-alpha</artifactId>
-                <version>${open.telemetry.alpha.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>io.opentelemetry</groupId>
-                <artifactId>opentelemetry-bom</artifactId>
-                <version>${open.telemetry.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>flow-bom</artifactId>
@@ -182,7 +168,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -196,7 +182,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.11.2</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -213,7 +199,7 @@
             <plugin>
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>2.16.0</version>
+                <version>2.26.0</version>
                 <configuration>
                     <configFile>eclipse/VaadinJavaConventions.xml</configFile>
                     <!-- Provide a dummy JS config file to avoid errors -->

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-parent</artifactId>
-        <version>2.1-SNAPSHOT</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus</artifactId>
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Also updates Quarkus to 3.20 LTS, cleans up POM files and bumps several maven plugin and dependencies.
