### PR TITLE
feat: make VaadinServiceEnabled bean unremovable by default

### DIFF
--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusProcessor.java
@@ -15,7 +15,6 @@
  */
 package com.vaadin.quarkus.deployment;
 
-import jakarta.servlet.annotation.WebServlet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -33,6 +32,7 @@ import io.quarkus.arc.deployment.ContextRegistrationPhaseBuildItem;
 import io.quarkus.arc.deployment.ContextRegistrationPhaseBuildItem.ContextConfiguratorBuildItem;
 import io.quarkus.arc.deployment.CustomScopeBuildItem;
 import io.quarkus.arc.deployment.IgnoreSplitPackageBuildItem;
+import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.bootstrap.model.ApplicationModel;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
@@ -49,6 +49,7 @@ import io.quarkus.undertow.deployment.ServletDeploymentManagerBuildItem;
 import io.quarkus.vertx.http.deployment.FilterBuildItem;
 import io.quarkus.websockets.client.deployment.ServerWebSocketContainerBuildItem;
 import io.quarkus.websockets.client.deployment.WebSocketDeploymentInfoBuildItem;
+import jakarta.servlet.annotation.WebServlet;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
@@ -67,6 +68,7 @@ import com.vaadin.quarkus.annotation.NormalRouteScoped;
 import com.vaadin.quarkus.annotation.NormalUIScoped;
 import com.vaadin.quarkus.annotation.RouteScoped;
 import com.vaadin.quarkus.annotation.UIScoped;
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
 import com.vaadin.quarkus.annotation.VaadinServiceScoped;
 import com.vaadin.quarkus.annotation.VaadinSessionScoped;
 import com.vaadin.quarkus.context.RouteContextWrapper;
@@ -161,6 +163,13 @@ class VaadinQuarkusProcessor {
         // Make and Route annotated Component a bean for injection
         additionalBeanDefiningAnnotationRegistry
                 .produce(new BeanDefiningAnnotationBuildItem(ROUTE_ANNOTATION));
+    }
+
+    @BuildStep
+    void markVaadinServiceEnabledBeanUnremovable(
+            BuildProducer<UnremovableBeanBuildItem> producer) {
+        producer.produce(UnremovableBeanBuildItem.targetWithAnnotation(
+                DotName.createSimple(VaadinServiceEnabled.class)));
     }
 
     @BuildStep

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/VaadinServiceEnabledBeanUnremovableTest.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/VaadinServiceEnabledBeanUnremovableTest.java
@@ -1,0 +1,69 @@
+package com.vaadin.flow.quarkus.test;
+
+import java.util.List;
+import java.util.Set;
+
+import io.quarkus.test.QuarkusUnitTest;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.vaadin.flow.i18n.DefaultI18NProvider;
+import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
+
+public class VaadinServiceEnabledBeanUnremovableTest {
+
+    @RegisterExtension
+    static QuarkusUnitTest unitTest = new QuarkusUnitTest().withApplicationRoot(
+            (jar) -> jar.addClasses(TestConfig.class, CustomI18NProvider.class)
+                    .add(EmptyAsset.INSTANCE, "META-INF/beans.xml"));
+
+    @Inject
+    BeanManager beanManager;
+
+    /*
+     * I18nProvider is looked up only programmatically, so Quarkus will remove
+     * the bean provided by TestConfig, unless it is marked @Unremovable. The
+     * Vaadin extension makes sure that all @VaadinServiceEnabled beans are
+     * automatically made unremovable, so the user does not need to apply
+     * the @Unremovable annotation manually.
+     */
+    @Test
+    void vaadinServiceEnabledBean_markedUnremovableByExtension() {
+        Set<Bean<?>> candidates = beanManager.getBeans(I18NProvider.class,
+                VaadinServiceEnabled.Literal.INSTANCE);
+        Assertions.assertEquals(1, candidates.size());
+
+        Bean<?> bean = candidates.iterator().next();
+        CreationalContext<?> context = beanManager
+                .createCreationalContext(bean);
+        I18NProvider injected = (I18NProvider) beanManager.getReference(bean,
+                I18NProvider.class, context);
+        Assertions.assertInstanceOf(CustomI18NProvider.class, injected);
+    }
+
+    private static class TestConfig {
+
+        @Produces
+        @VaadinServiceEnabled
+        @Singleton
+        I18NProvider customI18nProvider() {
+            return new CustomI18NProvider();
+        }
+    }
+
+    private static class CustomI18NProvider extends DefaultI18NProvider {
+
+        public CustomI18NProvider() {
+            super(List.of());
+        }
+    }
+}

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/service/TestErrorHandler.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/service/TestErrorHandler.java
@@ -28,7 +28,6 @@ import com.vaadin.quarkus.annotation.VaadinServiceScoped;
 
 @VaadinServiceEnabled
 @VaadinServiceScoped
-@Unremovable
 public class TestErrorHandler implements ErrorHandler {
 
     @Inject

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/service/TestSystemMessagesProvider.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/service/TestSystemMessagesProvider.java
@@ -27,7 +27,6 @@ import com.vaadin.quarkus.annotation.VaadinServiceScoped;
 
 @VaadinServiceEnabled
 @VaadinServiceScoped
-@Unremovable
 public class TestSystemMessagesProvider implements SystemMessagesProvider {
 
     public static final String EXPIRED_BY_TEST = "EXPIRED BY TEST";

--- a/runtime/src/main/java/com/vaadin/quarkus/BeanLookup.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/BeanLookup.java
@@ -15,16 +15,15 @@
  */
 package com.vaadin.quarkus;
 
-import jakarta.enterprise.context.spi.CreationalContext;
-import jakarta.enterprise.inject.AmbiguousResolutionException;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanManager;
-import jakarta.enterprise.util.AnnotationLiteral;
-
 import java.lang.annotation.Annotation;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.AmbiguousResolutionException;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
 
 import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
 
@@ -39,8 +38,6 @@ import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
  */
 class BeanLookup<T> {
 
-    static final Annotation SERVICE = new ServiceLiteral();
-
     private final BeanManager beanManager;
     private final Class<T> type;
     private final Annotation[] qualifiers;
@@ -52,11 +49,6 @@ class BeanLookup<T> {
 
     private static final Annotation[] ANY = new Annotation[] {
             new AnyLiteral() };
-
-    private static class ServiceLiteral
-            extends AnnotationLiteral<VaadinServiceEnabled>
-            implements VaadinServiceEnabled {
-    }
 
     @FunctionalInterface
     public interface UnsatisfiedHandler {

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
@@ -29,6 +29,7 @@ import com.vaadin.flow.di.InstantiatorFactory;
 import com.vaadin.flow.i18n.I18NProvider;
 import com.vaadin.flow.server.VaadinServiceInitListener;
 import com.vaadin.flow.server.auth.MenuAccessControl;
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
 
 /**
  * Instantiator implementation for Quarkus.
@@ -86,7 +87,8 @@ public class QuarkusInstantiator implements Instantiator {
     @Override
     public I18NProvider getI18NProvider() {
         final BeanLookup<I18NProvider> lookup = new BeanLookup<>(
-                getBeanManager(), I18NProvider.class, BeanLookup.SERVICE);
+                getBeanManager(), I18NProvider.class,
+                VaadinServiceEnabled.Literal.INSTANCE);
         if (i18NLoggingEnabled.compareAndSet(true, false)) {
             lookup.setUnsatisfiedHandler(() -> getLogger().info(
                     "Can't find any @VaadinServiceScoped bean implementing '{}'. "
@@ -106,7 +108,8 @@ public class QuarkusInstantiator implements Instantiator {
     @Override
     public MenuAccessControl getMenuAccessControl() {
         final BeanLookup<MenuAccessControl> lookup = new BeanLookup<>(
-                getBeanManager(), MenuAccessControl.class, BeanLookup.SERVICE);
+                getBeanManager(), MenuAccessControl.class,
+                VaadinServiceEnabled.Literal.INSTANCE);
         return lookup.lookupOrElseGet(delegate::getMenuAccessControl);
     }
 

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiatorFactory.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiatorFactory.java
@@ -24,7 +24,6 @@ import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
  * @see InstantiatorFactory
  */
 @VaadinServiceEnabled
-@Unremovable
 @ApplicationScoped
 public class QuarkusInstantiatorFactory implements InstantiatorFactory {
 

--- a/runtime/src/main/java/com/vaadin/quarkus/annotation/VaadinServiceEnabled.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/annotation/VaadinServiceEnabled.java
@@ -16,10 +16,12 @@
 
 package com.vaadin.quarkus.annotation;
 
-import jakarta.inject.Qualifier;
-
+import java.io.Serial;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -37,4 +39,25 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Target({ TYPE, METHOD, FIELD, PARAMETER })
 public @interface VaadinServiceEnabled {
+
+    /**
+     * Supports inline instantiation of the {@link VaadinServiceEnabled}
+     * annotation.
+     *
+     * @since 2.2
+     */
+    final class Literal extends AnnotationLiteral<VaadinServiceEnabled>
+            implements VaadinServiceEnabled {
+        /**
+         * Singleton instance of the {@code Literal} class, which allows inline
+         * instantiation of the {@link VaadinServiceEnabled} annotation. This
+         * instance provides a reusable, predefined implementation of the
+         * annotation for use in various contexts.
+         */
+        public static final Literal INSTANCE = new Literal();
+
+        @Serial
+        private static final long serialVersionUID = 1L;
+    }
+
 }


### PR DESCRIPTION
VaadinServiceEnabled annotated beans are usually looked up programmatically by Vaadin components. This means that the developer needs to mark the bean with Unremovable annotation also, to prevent Quarkus from removing the bean at build time.

This change adds a build step to the extension that marks all beans annotated with VaadinServiceEnabled as unremovable.

Fixes #147