### PR TITLE
feat: detect specific Executor for VaadinService

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>quarkus-junit5-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/AbstractVaadinServiceExecutorTestSupport.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/AbstractVaadinServiceExecutorTestSupport.java
@@ -1,0 +1,44 @@
+package com.vaadin.flow.quarkus.test.executor;
+
+import java.util.concurrent.Executor;
+
+import io.quarkus.test.QuarkusUnitTest;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.server.ServiceException;
+
+abstract class AbstractVaadinServiceExecutorTestSupport {
+
+    @Inject
+    BeanManager beanManager;
+
+    @Inject
+    ManagedExecutor managedExecutor;
+
+    abstract Executor expectedExecutor();
+
+    @Test
+    void getExecutor_serviceInitialized_getsExpectedExecutor()
+            throws ServiceException {
+        var service = new TestQuarkusVaadinServletService(beanManager);
+        service.init();
+        var executor = service.getExecutor();
+        Assertions.assertSame(expectedExecutor(), executor);
+    }
+
+    static QuarkusUnitTest quarkusUnitTest(Class<?>... testClasses) {
+        return new QuarkusUnitTest()
+                .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                        .addClass(TestQuarkusVaadinServletService.class)
+                        .addClasses(testClasses).addAsManifestResource(
+                                EmptyAsset.INSTANCE, "beans.xml"));
+    }
+
+}

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceAlternativeExecutorTest.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceAlternativeExecutorTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.quarkus.test.executor;
+
+import java.util.concurrent.Executor;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
+
+class QuarkusVaadinServletServiceAlternativeExecutorTest
+        extends AbstractVaadinServiceExecutorTestSupport {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = quarkusUnitTest(TestConfig.class);
+
+    @Override
+    Executor expectedExecutor() {
+        // Alternative bean is ignored, so the custom executor should be used.
+        return TestConfig.CUSTOM_EXECUTOR;
+    }
+
+    static class TestConfig {
+
+        public static final Executor CUSTOM_EXECUTOR = Mockito.mock(
+                Executor.class, Mockito.withSettings().name("CustomExecutor"));
+        public static final Executor ALTERNATIVE_EXECUTOR = Mockito.mock(
+                Executor.class,
+                Mockito.withSettings().name("AlternativeExecutor"));
+
+        @Produces
+        @Singleton
+        @VaadinServiceEnabled
+        @Unremovable
+        Executor vaadinExecutor1() {
+            return CUSTOM_EXECUTOR;
+        }
+
+        @Produces
+        @Singleton
+        @VaadinServiceEnabled
+        @Unremovable
+        @Alternative
+        Executor vaadinExecutor2() {
+            return ALTERNATIVE_EXECUTOR;
+        }
+    }
+}

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceAmbiguousExecutorTest.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceAmbiguousExecutorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.quarkus.test.executor;
+
+import java.util.concurrent.Executor;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.test.QuarkusUnitTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.DeploymentException;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QuarkusVaadinServletServiceAmbiguousExecutorTest
+        extends AbstractVaadinServiceExecutorTestSupport {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = quarkusUnitTest(TestConfig.class)
+            .assertException(error -> {
+                Assertions.assertInstanceOf(DeploymentException.class, error);
+                error = error.getCause();
+                Assertions.assertInstanceOf(IllegalStateException.class, error);
+                assertTrue(error.getMessage()
+                        .contains("at most one Executor bean"));
+                assertTrue(
+                        error.getMessage().contains("@VaadinServiceEnabled"));
+            });
+
+    @Override
+    Executor expectedExecutor() {
+        throw new AssertionError(
+                "Should have failed during build due to ambiguous executor");
+    }
+
+    @ApplicationScoped
+    private static class TestConfig {
+
+        @Produces
+        @Singleton
+        @VaadinServiceEnabled
+        @Unremovable
+        Executor vaadinExecutor1() {
+            return Mockito.mock(Executor.class);
+        }
+
+        @Produces
+        @Singleton
+        @VaadinServiceEnabled
+        @Unremovable
+        Executor vaadinExecutor2() {
+            return Mockito.mock(Executor.class);
+        }
+    }
+}

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceCustomExecutorTest.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceCustomExecutorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.quarkus.test.executor;
+
+import java.util.concurrent.Executor;
+
+import io.quarkus.arc.Unremovable;
+import io.quarkus.runtime.Startup;
+import io.quarkus.test.QuarkusUnitTest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
+
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
+
+class QuarkusVaadinServletServiceCustomExecutorTest
+        extends AbstractVaadinServiceExecutorTestSupport {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = quarkusUnitTest(TestConfig.class);
+
+    @Override
+    Executor expectedExecutor() {
+        return TestConfig.CUSTOM_EXECUTOR;
+    }
+
+    static class TestConfig {
+
+        static final Executor CUSTOM_EXECUTOR = Mockito.mock(Executor.class);
+
+        @Produces
+        @Singleton
+        @VaadinServiceEnabled
+        @Unremovable
+        Executor vaadinExecutor() {
+            return CUSTOM_EXECUTOR;
+        }
+    }
+}

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceManagedExecutorTest.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/QuarkusVaadinServletServiceManagedExecutorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.vaadin.flow.quarkus.test.executor;
+
+import java.util.concurrent.Executor;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class QuarkusVaadinServletServiceManagedExecutorTest
+        extends AbstractVaadinServiceExecutorTestSupport {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = quarkusUnitTest();
+
+    @Override
+    Executor expectedExecutor() {
+        return managedExecutor;
+    }
+
+}

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/TestQuarkusVaadinServletService.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/executor/TestQuarkusVaadinServletService.java
@@ -1,0 +1,46 @@
+package com.vaadin.flow.quarkus.test.executor;
+
+import java.util.Properties;
+
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.servlet.ServletContext;
+
+import com.vaadin.flow.di.Lookup;
+import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.quarkus.QuarkusVaadinServlet;
+import com.vaadin.quarkus.QuarkusVaadinServletService;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TestQuarkusVaadinServletService extends QuarkusVaadinServletService {
+
+    TestQuarkusVaadinServletService(BeanManager beanManager) {
+        super(mock(QuarkusVaadinServlet.class),
+                mock(DeploymentConfiguration.class), beanManager);
+        when(getServlet().getServletName()).thenReturn("QuarkusVaadinServlet");
+        when(getServlet().getService()).thenReturn(this);
+        final ServletContext servletcontext = mock(ServletContext.class);
+        when(getServlet().getServletContext()).thenReturn(servletcontext);
+        when(servletcontext.getAttribute(Lookup.class.getName()))
+                .thenReturn(mock(Lookup.class));
+        DeploymentConfiguration config = getDeploymentConfiguration();
+        Properties properties = new Properties();
+        when(config.getInitParameters()).thenReturn(properties);
+    }
+
+    // We have nothing to do with atmosphere,
+    // and mocking is much easier without it.
+    @Override
+    protected boolean isAtmosphereAvailable() {
+        return false;
+    }
+
+    @Override
+    public void setClassLoader(ClassLoader classLoader) {
+        if (classLoader != null) {
+            super.setClassLoader(classLoader);
+        }
+    }
+
+}


### PR DESCRIPTION
Enhances Quarkus VaadinService implementation trying to detect the best Executor option available at runtime. It first looks for an Executor bean annotated with `@VaadinServiceEnabled` and then it falls back to the Quarkus provided ManagedExecutor.

Closes #200