### PR TITLE
chore: bump project to 3.0

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-parent</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-buildtools</artifactId>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-deployment</artifactId>

--- a/integration-tests/codestarts/pom.xml
+++ b/integration-tests/codestarts/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-codestarts-tests</artifactId>

--- a/integration-tests/common-test-code/pom.xml
+++ b/integration-tests/common-test-code/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-common-test-code</artifactId>

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/SmokeTestIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/SmokeTestIT.java
@@ -1,14 +1,13 @@
 package com.vaadin.flow.quarkus.it;
 
-import com.vaadin.flow.component.html.testbench.SpanElement;
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
-import com.vaadin.flow.component.html.testbench.LabelElement;
 import com.vaadin.flow.component.html.testbench.NativeButtonElement;
+import com.vaadin.flow.component.html.testbench.SpanElement;
 import com.vaadin.flow.test.AbstractChromeIT;
 
 @QuarkusIntegrationTest

--- a/integration-tests/custom-websocket-dependency/pom.xml
+++ b/integration-tests/custom-websocket-dependency/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -26,13 +26,13 @@
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-client-api</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.2.7</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-development-tests</artifactId>
@@ -167,36 +167,6 @@
                         </plugin>
                         <plugin>
                             <artifactId>maven-failsafe-plugin</artifactId>
-                            <dependencies>
-                                <dependency>
-                                    <groupId>javax.xml.bind</groupId>
-                                    <artifactId>jaxb-api</artifactId>
-                                    <version>2.2.11</version>
-                                </dependency>
-                                <dependency>
-                                    <groupId>com.sun.xml.bind</groupId>
-                                    <artifactId>jaxb-core</artifactId>
-                                    <version>2.2.11</version>
-                                </dependency>
-                                <dependency>
-                                    <groupId>com.sun.xml.bind</groupId>
-                                    <artifactId>jaxb-impl</artifactId>
-                                    <version>2.2.11</version>
-                                </dependency>
-                                <dependency>
-                                    <groupId>com.sun.activation</groupId>
-                                    <artifactId>javax.activation</artifactId>
-                                    <version>1.2.0</version>
-                                </dependency>
-                            </dependencies>
-                        </plugin>
-                        <plugin>
-                            <groupId>com.lazerycode.selenium</groupId>
-                            <artifactId>driver-binary-downloader-maven-plugin
-                            </artifactId>
-                            <version>
-                                ${driver.binary.downloader.maven.plugin.version}
-                            </version>
                             <dependencies>
                                 <dependency>
                                     <groupId>javax.xml.bind</groupId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-integration-tests</artifactId>

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus-production-tests</artifactId>

--- a/integration-tests/reusable-theme/pom.xml
+++ b/integration-tests/reusable-theme/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -16,7 +16,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <vaadin-lumo-theme.version>24.8-SNAPSHOT</vaadin-lumo-theme.version>
+        <vaadin-lumo-theme.version>25.0-SNAPSHOT</vaadin-lumo-theme.version>
     </properties>
 
     <dependencies>

--- a/integration-tests/test-addons/addon-with-jandex/pom.xml
+++ b/integration-tests/test-addons/addon-with-jandex/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -60,7 +60,7 @@
             <plugin>
                 <groupId>io.smallrye</groupId>
                 <artifactId>jandex-maven-plugin</artifactId>
-                <version>3.2.7</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>make-index</id>

--- a/integration-tests/test-addons/addon-without-jandex/pom.xml
+++ b/integration-tests/test-addons/addon-without-jandex/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-integration-tests</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-parent</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Vaadin Quarkus - Parent</name>
@@ -41,8 +41,8 @@
         <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
 
-        <vaadin.flow.version>24.8-SNAPSHOT</vaadin.flow.version>
-        <quarkus.version>3.20.1</quarkus.version>
+        <vaadin.flow.version>25.0-SNAPSHOT</vaadin.flow.version>
+        <quarkus.version>3.24.0</quarkus.version>
         <open.telemetry.alpha.version>1.16.0-alpha</open.telemetry.alpha.version>
         <open.telemetry.version>1.16.0</open.telemetry.version>
 
@@ -107,13 +107,13 @@
             <dependency>
                 <groupId>jakarta.servlet</groupId>
                 <artifactId>jakarta.servlet-api</artifactId>
-                <version>6.0.0</version>
+                <version>6.1.0</version>
             </dependency>
 
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>4.0.1</version>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>4.1.0</version>
             </dependency>
 
         </dependencies>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-quarkus-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>vaadin-quarkus</artifactId>

--- a/runtime/src/test/java/com/vaadin/quarkus/context/UIUnderTestContext.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/context/UIUnderTestContext.java
@@ -43,7 +43,7 @@ public class UIUnderTestContext implements UnderTestContext {
         ui = new UI();
         ui.getInternals().setSession(session);
         uiIdNdx++;
-        ui.doInit(null, uiIdNdx);
+        ui.doInit(null, uiIdNdx, "appId");
     }
 
     private void mockSession() {


### PR DESCRIPTION
Also updates to Vaadin 25.0 and JakartaEE 11.
It uses Quarkus 3.24 (non LTS) waiting for the
3.27 LTS release in September/October.
