### PR TITLE
chore: prevent the extension to be listed in DevUI (#208) (CP: 2.2)

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -10,6 +10,7 @@ metadata:
   categories:
     - "web"
   status: "stable"
+  unlisted: "true"
   codestart:
     name: "vaadin-flow"
     languages:


### PR DESCRIPTION
Adds the unlisted key to the extension metadata to prevent it to be shown in Dev UI.
The platform extension will have the flag set to false, so that there will be only one Vaadin extension shown in Dev UI.

Fixes #160