### PR TITLE
feat: add embedded Vaadin plugin

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -32,6 +32,11 @@
             <artifactId>vaadin-quarkus</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-plugin-base</artifactId>
+            <version>${vaadin.flow.version}</version>
+        </dependency>
 
         <!-- Test scope -->
         <dependency>

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/QuarkusPluginAdapter.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/QuarkusPluginAdapter.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2025 Marco Collovati, Dario Götze
+ * Copyright 2000-2025 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.quarkus.deployment.vaadinplugin;
 

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/QuarkusPluginAdapter.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/QuarkusPluginAdapter.java
@@ -1,0 +1,480 @@
+/*
+ * Copyright 2025 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.quarkus.deployment.vaadinplugin;
+
+import com.vaadin.flow.internal.StringUtil;
+import com.vaadin.flow.plugin.base.BuildFrontendUtil;
+import com.vaadin.flow.plugin.base.PluginAdapterBuild;
+import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.frontend.installer.Platform;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.scanner.ReflectionsClassFinder;
+import com.vaadin.flow.utils.FlowFileUtils;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.workspace.SourceDir;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.runtime.configuration.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Quarkus implementation of Vaadin build plugin adapter.
+ */
+class QuarkusPluginAdapter implements PluginAdapterBuild {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(QuarkusPluginAdapter.class);
+
+    private final VaadinBuildTimeConfig config;
+    private final ApplicationModel model;
+    private final WorkspaceModule appModule;
+    private final SourceDir sourcesDir;
+    private final SourceDir resourcesDir;
+
+    /**
+     * Creates a new instance of {@link QuarkusPluginAdapter} for the give build
+     * configuration and application.
+     *
+     * @param config
+     *            the Vaadin build configuration.
+     * @param applicationModel
+     *            the application model.
+     */
+    QuarkusPluginAdapter(VaadinBuildTimeConfig config,
+            ApplicationModel applicationModel) {
+        this(config, applicationModel, applicationModel.getApplicationModule());
+    }
+
+    /**
+     * Creates a new instance of {@link QuarkusPluginAdapter} for the give build
+     * configuration and application.
+     *
+     * @param config
+     *            the Vaadin build configuration.
+     * @param applicationModel
+     *            the application model.
+     * @param appModule
+     *            the application module.
+     */
+    QuarkusPluginAdapter(VaadinBuildTimeConfig config,
+            ApplicationModel applicationModel, WorkspaceModule appModule) {
+        this.config = config;
+        this.model = applicationModel;
+        this.appModule = appModule;
+        SourceDir assumedSources = SourceDir.of(
+                appModule.getModuleDir().toPath()
+                        .resolve(Paths.get("src", "main", "java")),
+                appModule.getBuildDir().toPath().resolve("classes"));
+        SourceDir assumedResources = SourceDir.of(
+                appModule.getModuleDir().toPath()
+                        .resolve(Paths.get("src", "main", "resources")),
+                appModule.getBuildDir().toPath().resolve("classes"));
+        if (appModule.hasMainSources()) {
+            sourcesDir = appModule.getMainSources().getSourceDirs().stream()
+                    .findFirst().orElse(assumedSources);
+            resourcesDir = appModule.getMainSources().getResourceDirs().stream()
+                    .findFirst().orElse(assumedResources);
+        } else {
+            sourcesDir = assumedSources;
+            resourcesDir = assumedResources;
+        }
+    }
+
+    @Override
+    public File frontendResourcesDirectory() {
+        return resolveProjectDirectory(config.frontendResourcesDirectory(),
+                "vaadin.build.frontendResourcesDirectory");
+    }
+
+    @Override
+    public boolean generateBundle() {
+        return config.generateBundle();
+    }
+
+    @Override
+    public boolean generateEmbeddableWebComponents() {
+        return config.generateEmbeddableWebComponents();
+    }
+
+    @Override
+    public boolean optimizeBundle() {
+        return config.optimizeBundle();
+    }
+
+    @Override
+    public boolean runNpmInstall() {
+        return config.runNpmInstall();
+    }
+
+    @Override
+    public boolean ciBuild() {
+        return config.ciBuild();
+    }
+
+    @Override
+    public boolean forceProductionBuild() {
+        return config.forceProductionBuild();
+    }
+
+    @Override
+    public boolean compressBundle() {
+        return true;
+    }
+
+    @Override
+    public boolean checkRuntimeDependency(String groupId, String artifactId,
+            Consumer<String> missingDependencyMessageConsumer) {
+        if (model.getRuntimeDependencies().stream().noneMatch(
+                dependency -> dependency.getGroupId().equals(groupId))) {
+            if (missingDependencyMessageConsumer != null) {
+                missingDependencyMessageConsumer.accept(String.format(
+                        """
+                                The dependency %1$s:%2$s has not been found in the project configuration.
+                                Please add the following dependency to your POM file:
+
+                                <dependency>
+                                    <groupId>%1$s</groupId>
+                                    <artifactId>%2$s</artifactId>
+                                    <scope>runtime</scope>
+                                </dependency>
+                                """,
+                        groupId, artifactId));
+            }
+            return true;
+        }
+        return true;
+    }
+
+    @Override
+    public File applicationProperties() {
+        return config.applicationProperties();
+    }
+
+    @Override
+    public boolean eagerServerLoad() {
+        return config.eagerServerLoad();
+    }
+
+    @Override
+    public File frontendDirectory() {
+        return resolveProjectDirectory(config.frontendDirectory(),
+                "vaadin.build.frontedDirectory");
+    }
+
+    private File resolveProjectDirectory(File directory, String name) {
+        return resolveDirectory(projectBaseDirectory().toFile(), directory,
+                name);
+    }
+
+    private File resolveBuildDirectory(File directory, String name) {
+        return resolveDirectory(resourcesDir.getOutputDir().toFile(), directory,
+                name);
+    }
+
+    private File resolveDirectory(File base, File directory, String key) {
+        if (directory.isAbsolute() && directory.isDirectory()) {
+            return directory;
+        }
+        directory = base.toPath().resolve(directory.toPath()).toFile();
+        if (directory.exists() && !directory.isDirectory()) {
+            throw new ConfigurationException(
+                    key + " must be a directory: " + directory, Set.of(key));
+        }
+        return directory;
+    }
+
+    @Override
+    public File generatedTsFolder() {
+        return config.generatedTsFolder().orElseGet(() -> frontendDirectory()
+                .toPath().resolve(FrontendUtils.GENERATED).toFile());
+    }
+
+    private ClassFinder classFinder;
+
+    @Override
+    public ClassFinder getClassFinder() {
+        if (classFinder == null) {
+            URL[] urls = buildClasspath().map(Path::toFile)
+                    .map(FlowFileUtils::convertToUrl).toArray(URL[]::new);
+            URLClassLoader classLoader = new URLClassLoader(urls,
+                    Thread.currentThread().getContextClassLoader());
+            classFinder = new ReflectionsClassFinder(classLoader, urls);
+        }
+        return classFinder;
+    }
+
+    @Override
+    public Set<File> getJarFiles() {
+        return model.getRuntimeDependencies().stream()
+                .flatMap(dep -> dep.getResolvedPaths().stream())
+                .map(Path::toFile).filter(file -> !file.isDirectory())
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public boolean isJarProject() {
+        return true;
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return false;
+    }
+
+    @Override
+    public File javaSourceFolder() {
+        return sourcesDir.getDir().toFile();
+    }
+
+    @Override
+    public File javaResourceFolder() {
+        return resourcesDir.getDir().toFile();
+    }
+
+    @Override
+    public boolean isFrontendIgnoreVersionChecks() {
+        return config.frontendIgnoreVersionChecks();
+    }
+
+    @Override
+    public void logDebug(CharSequence charSequence) {
+        LOGGER.debug(charSequence.toString());
+    }
+
+    @Override
+    public void logDebug(CharSequence charSequence, Throwable throwable) {
+        LOGGER.debug(charSequence.toString(), throwable);
+    }
+
+    @Override
+    public void logInfo(CharSequence charSequence) {
+        LOGGER.info(charSequence.toString());
+    }
+
+    @Override
+    public void logWarn(CharSequence charSequence) {
+        LOGGER.warn(charSequence.toString());
+    }
+
+    @Override
+    public void logError(CharSequence charSequence) {
+        LOGGER.error(charSequence.toString());
+    }
+
+    @Override
+    public void logWarn(CharSequence charSequence, Throwable throwable) {
+        LOGGER.warn(charSequence.toString(), throwable);
+    }
+
+    @Override
+    public void logError(CharSequence charSequence, Throwable throwable) {
+        LOGGER.error(charSequence.toString(), throwable);
+    }
+
+    @Override
+    public URI nodeDownloadRoot() throws URISyntaxException {
+        String nodeDownloadRoot = config.nodeDownloadRoot()
+                .orElseGet(() -> Platform.guess().getNodeDownloadRoot());
+        try {
+            return new URI(nodeDownloadRoot);
+        } catch (URISyntaxException e) {
+            logError("Failed to parse nodeDownloadRoot uri", e);
+            throw new URISyntaxException(nodeDownloadRoot,
+                    "Failed to parse nodeDownloadRoot uri");
+        }
+    }
+
+    @Override
+    public boolean nodeAutoUpdate() {
+        return config.nodeAutoUpdate();
+    }
+
+    @Override
+    public String nodeVersion() {
+        return config.nodeVersion();
+    }
+
+    @Override
+    public File npmFolder() {
+        return config.npmFolder()
+                .map(dir -> resolveProjectDirectory(dir, "npmFolder"))
+                .orElseGet(() -> projectBaseDirectory().toFile());
+    }
+
+    @Override
+    public File openApiJsonFile() {
+        return config.openApiJsonFile();
+    }
+
+    @Override
+    public boolean pnpmEnable() {
+        return config.pnpmEnable();
+    }
+
+    @Override
+    public boolean bunEnable() {
+        return config.bunEnable();
+    }
+
+    @Override
+    public boolean useGlobalPnpm() {
+        return config.useGlobalPnpm();
+    }
+
+    @Override
+    public Path projectBaseDirectory() {
+        return appModule.getModuleDir().toPath();
+    }
+
+    @Override
+    public boolean requireHomeNodeExec() {
+        return config.requireHomeNodeExec();
+    }
+
+    @Override
+    public File servletResourceOutputDirectory() {
+        return resolveBuildDirectory(config.resourceOutputDirectory(),
+                "resourceOutputDirectory");
+    }
+
+    @Override
+    public File webpackOutputDirectory() {
+        return frontendOutputDirectory();
+    }
+
+    @Override
+    public File frontendOutputDirectory() {
+        File outputDir = resolveBuildDirectory(config.frontendOutputDirectory(),
+                "frontendOutputDirectory");
+        config.webpackOutputDirectory()
+                .map(f -> resolveBuildDirectory(f, "webpackOutputDirectory"))
+                .filter(f -> !f.equals(outputDir))
+                .ifPresent(deprecatedOutputDir -> logWarn(
+                        "Both 'frontendOutputDirectory' and 'webpackOutputDirectory' are set. "
+                                + "'webpackOutputDirectory' property will be removed in future releases and will be ignored. "
+                                + "Please use only 'frontendOutputDirectory'."));
+        return outputDir;
+    }
+
+    @Override
+    public String buildFolder() {
+        Path projectDir = appModule.getModuleDir().toPath();
+        Path buildDir = appModule.getBuildDir().toPath();
+        if (buildDir.startsWith(projectDir)) {
+            return projectDir.relativize(buildDir).toString();
+        }
+        return buildDir.toString();
+    }
+
+    @Override
+    public List<String> postinstallPackages() {
+        return config.postinstallPackages().orElseGet(List::of);
+    }
+
+    @Override
+    public boolean isFrontendHotdeploy() {
+        return true;
+    }
+
+    @Override
+    public boolean skipDevBundleBuild() {
+        return config.skipDevBundleBuild();
+    }
+
+    @Override
+    public boolean isPrepareFrontendCacheDisabled() {
+        return false;
+    }
+
+    @Override
+    public boolean isReactEnabled() {
+        return config.reactEnabled()
+                .orElseGet(() -> FrontendUtils.isReactRouterRequired(
+                        BuildFrontendUtil.getFrontendDirectory(this)));
+    }
+
+    @Override
+    public String applicationIdentifier() {
+        return config.applicationIdentifier().filter(id -> !id.isBlank())
+                .orElseGet(() -> "app-" + StringUtil.getHash(
+                        model.getAppArtifact().getGroupId()
+                                + model.getAppArtifact().getArtifactId(),
+                        StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public List<String> frontendExtraFileExtensions() {
+        return config.frontendExtraFileExtensions().orElseGet(List::of);
+    }
+
+    @Override
+    public boolean isNpmExcludeWebComponents() {
+        return config.npmExcludeWebComponents();
+    }
+
+    @Override
+    public boolean isCommercialBannerEnabled() {
+        return config.commercialWithBanner();
+    }
+
+    /**
+     * Gets whether to cleans generated frontend files after the execution of
+     * the frontend build. This is generally enabled by default to ensure a
+     * clean state for after the build completes.
+     *
+     * @return {@code true} if the frontend files will be cleaned, {@code false}
+     *         otherwise
+     */
+    public boolean cleanFrontendFiles() {
+        return config.cleanFrontendFiles();
+    }
+
+    /**
+     * Resolves and returns the build output directory.
+     *
+     * @return the path representing the build output directory.
+     */
+    Path buildDir() {
+        return resourcesDir.getOutputDir();
+    }
+
+    /**
+     * Collects the path of the artifacts that compose the application
+     * classpath.
+     *
+     * @return the path of the artifacts that compose the application classpath.
+     */
+    private Stream<Path> buildClasspath() {
+        return Stream.concat(
+                appModule.getMainSources().getOutputTree().getRoots().stream(),
+                model.getRuntimeDependencies().stream()
+                        .flatMap(dep -> dep.getResolvedPaths().stream()));
+    }
+}

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
@@ -36,7 +36,7 @@ public interface VaadinBuildTimeConfig {
     /**
      * Gets if Vaadin Quarkus Plugins is enabled.
      */
-    @WithDefault("false")
+    @WithDefault("true")
     boolean enabled();
 
     /**

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2025 Marco Collovati, Dario Götze
+ * Copyright 2000-2025 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.quarkus.deployment.vaadinplugin;
 

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2025 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.quarkus.deployment.vaadinplugin;
+
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.frontend.FrontendTools;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+
+import static com.vaadin.flow.server.Constants.VAADIN_SERVLET_RESOURCES;
+import static com.vaadin.flow.server.frontend.FrontendUtils.FRONTEND;
+
+@ConfigMapping(prefix = "vaadin.build")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface VaadinBuildTimeConfig {
+
+    /**
+     * Gets if Vaadin Quarkus Plugins is enabled.
+     */
+    @WithDefault("false")
+    boolean enabled();
+
+    /**
+     * Defines the project frontend directory from where resources should be
+     * copied from for use with the frontend build tool.
+     */
+    @WithDefault(Constants.LOCAL_FRONTEND_RESOURCES_PATH)
+    File frontendResourcesDirectory();
+
+    /**
+     * Whether to generate a bundle from the project frontend sources or not.
+     * Defaults to {@literal true}
+     */
+    @WithDefault("true")
+    boolean generateBundle();
+
+    /**
+     * Whether to generate embeddable web components from WebComponentExporter
+     * inheritors.
+     */
+    @WithDefault("true")
+    boolean generateEmbeddableWebComponents();
+
+    /**
+     * Whether to use byte code scanner strategy to discover frontend
+     * components.
+     */
+    @WithDefault("true")
+    boolean optimizeBundle();
+
+    /**
+     * Whether to run npm install after updating dependencies.
+     */
+    @WithDefault("true")
+    boolean runNpmInstall();
+
+    /**
+     * Setting this to true will run npm ci instead of npm install when using
+     * npm. If using pnpm, the install will be run with --frozen-lockfile
+     * parameter. This makes sure that the versions in package lock file will
+     * not be overwritten and production builds are reproducible.
+     */
+    @WithDefault("false")
+    boolean ciBuild();
+
+    /**
+     * Setting this to true will force a build of the production build even if
+     * there is a default production bundle that could be used. Created
+     * production bundle optimization is defined by optimizeBundle parameter.
+     */
+    @WithDefault("false")
+    boolean forceProductionBuild();
+
+    /**
+     * Control cleaning of generated frontend files when executing
+     * 'build-frontend'. Mainly this is wanted to be true which it is by
+     * default.
+     */
+    @WithDefault("true")
+    boolean cleanFrontendFiles();
+
+    /**
+     * Application properties file in Quarkus project.
+     */
+    @WithDefault("src/main/resources/application.properties")
+    File applicationProperties();
+
+    /**
+     * Whether to insert the initial UIDL object in the bootstrap index.html
+     */
+    @WithDefault("false")
+    boolean eagerServerLoad();
+
+    /**
+     * A directory with project's frontend source files.
+     */
+    @WithDefault("src/main/" + FRONTEND)
+    File frontendDirectory();
+
+    /**
+     * The folder where flow will put TS API files for client projects.
+     */
+    Optional<File> generatedTsFolder();
+
+    /**
+     * Download node. js from this URL. Handy in heavily firewalled corporate
+     * environments where the node.js download can be provided from an intranet
+     * mirror. Defaults to null which will cause the downloader to use
+     * NodeInstaller.DEFAULT_NODEJS_DOWNLOAD_ROOT.
+     *
+     * Example: {@literal https://nodejs.org/dist/}
+     */
+    Optional<String> nodeDownloadRoot();
+
+    /**
+     * Setting defining if the automatically installed node version may be
+     * updated to the default Vaadin node version.
+     */
+    @WithDefault("" + Constants.DEFAULT_NODE_AUTO_UPDATE)
+    boolean nodeAutoUpdate();
+
+    /**
+     * The node. js version to be used when node. js is installed automatically
+     * by Vaadin, for example `"v16.0.0"`. Defaults to the Vaadin-default node
+     * version - see FrontendTools for details.
+     */
+    @WithDefault(FrontendTools.DEFAULT_NODE_VERSION)
+    String nodeVersion();
+
+    /**
+     * The folder where `package. json` file is located. Default is project root
+     * dir.
+     */
+    Optional<File> npmFolder();
+
+    /**
+     * Default generated path of the OpenAPI json.
+     */
+    @WithDefault("generated-resources/openapi.json")
+    File openApiJsonFile();
+
+    /**
+     * Instructs to use pnpm for installing npm frontend resources.
+     */
+    @WithDefault("" + Constants.ENABLE_PNPM_DEFAULT)
+    boolean pnpmEnable();
+
+    /**
+     * Instructs to use bun for installing npm frontend resources.
+     */
+    @WithDefault("" + Constants.ENABLE_BUN_DEFAULT)
+    boolean bunEnable();
+
+    /**
+     * Instructs to use globally installed pnpm tool or the default supported
+     * pnpm version.
+     */
+    @WithDefault("" + Constants.GLOBAL_PNPM_DEFAULT)
+    boolean useGlobalPnpm();
+
+    /**
+     * Whether vaadin home node executable usage is forced. If it's set to true
+     * then vaadin home 'node' is checked and installed if it's absent. Then it
+     * will be used instead of globally 'node' or locally installed 'node'.
+     */
+    @WithDefault("" + Constants.DEFAULT_REQUIRE_HOME_NODE_EXECUTABLE)
+    boolean requireHomeNodeExec();
+
+    /**
+     * Defines the output directory for generated non-served resources, such as
+     * the token file.
+     */
+    @WithDefault(VAADIN_SERVLET_RESOURCES)
+    File resourceOutputDirectory();
+
+    /**
+     * The folder where the frontend build tool should output index. js and
+     * other generated files.
+     *
+     * @deprecated use {@link #frontendOutputDirectory()}
+     */
+    @Deprecated(since = "24.8", forRemoval = true)
+    Optional<File> webpackOutputDirectory();
+
+    /**
+     * The folder where the frontend build tool should output index. js and
+     * other generated files.
+     */
+    @WithDefault(Constants.VAADIN_WEBAPP_RESOURCES)
+    File frontendOutputDirectory();
+
+    /**
+     * Additional npm packages to run post install scripts for.
+     * <p>
+     * Post install is automatically run for internal dependencies which rely on
+     * post install scripts to work, e.g. esbuild.
+     */
+    Optional<List<String>> postinstallPackages();
+
+    /**
+     * Whether to disable dev bundle rebuild.
+     */
+    @WithDefault("false")
+    boolean skipDevBundleBuild();
+
+    /**
+     * Whether to enable react
+     */
+    Optional<Boolean> reactEnabled();
+
+    /**
+     * Identifier for the application. If not specified, defaults to the hashed
+     * value of 'groupId:artifactId'.
+     */
+    Optional<String> applicationIdentifier();
+
+    /**
+     * Parameter for adding file extensions to handle when generating bundles.
+     * Hashes are calculated for these files as part of detecting if a new
+     * bundle should be generated. From the commandline use comma separated list
+     * -Ddevmode.frontendExtraFileExtensions="svg,ico" In plugin configuration
+     * use comma separated values svg,ico
+     */
+    Optional<List<String>> frontendExtraFileExtensions();
+
+    /**
+     * Whether to exclude npm packages for web components.
+     */
+    @WithDefault("false")
+    boolean npmExcludeWebComponents();
+
+    /**
+     * Set to {@code true} to ignore node/npm tool version checks.
+     * <p>
+     * </p>
+     * Note that disabling frontend tools version checking could cause failing
+     * builds and other issues that are difficult to debug.
+     */
+    @WithDefault("false")
+    boolean frontendIgnoreVersionChecks();
+
+    /**
+     * Allows building a version of the application with a commercial banner
+     * when commercial components are used without a license key.
+     */
+    @WithDefault("false")
+    boolean commercialWithBanner();
+}

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
@@ -1,17 +1,17 @@
 /*
- * Copyright 2025 Marco Collovati, Dario Götze
+ * Copyright 2000-2025 Vaadin Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.vaadin.quarkus.deployment.vaadinplugin;
 

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
@@ -95,7 +95,7 @@ public final class VaadinPlugin {
                 module = WorkspaceInfo.load(outputTarget);
             } catch (Exception e) {
                 throw new BuildException(
-                        "Cannot load workspace information for Vaadin plugin",
+                        "Cannot load workspace information for Vaadin plugin. quarkus.bootstrap.workspace-discovery=true might be required.",
                         e, List.of());
             }
         }

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2025 Marco Collovati, Dario Götze
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vaadin.quarkus.deployment.vaadinplugin;
+
+import com.vaadin.experimental.FeatureFlags;
+import com.vaadin.flow.component.dependency.JavaScript;
+import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.dependency.NpmPackage;
+import com.vaadin.flow.plugin.base.BuildFrontendUtil;
+import com.vaadin.flow.server.Constants;
+import com.vaadin.flow.server.ExecutionFailedException;
+import com.vaadin.flow.server.frontend.BundleValidationUtil;
+import com.vaadin.flow.server.frontend.FrontendUtils;
+import com.vaadin.flow.server.frontend.Options;
+import com.vaadin.flow.server.frontend.TaskCleanFrontendFiles;
+import com.vaadin.flow.server.frontend.scanner.ClassFinder;
+import com.vaadin.flow.server.frontend.scanner.FrontendDependenciesScanner;
+import com.vaadin.flow.theme.Theme;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+import com.vaadin.pro.licensechecker.MissingLicenseKeyException;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.builder.BuildException;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
+
+/**
+ * Implementation of the Vaadin plugin.
+ * <p>
+ * </p>
+ * This class is a porting of Vaadin Maven prepare-frontend and build-frontend
+ * mojos.
+ */
+public final class VaadinPlugin {
+
+    private final QuarkusPluginAdapter pluginAdapter;
+
+    /**
+     * Creates a new instance of Quarkus Vaadin plugin for the given build
+     * configuration and application.
+     *
+     * @param vaadinConfig
+     *            the Vaadin build configuration.
+     * @param applicationModel
+     *            the application model.
+     */
+    private VaadinPlugin(VaadinBuildTimeConfig vaadinConfig,
+            ApplicationModel applicationModel, WorkspaceModule appModule) {
+        this.pluginAdapter = new QuarkusPluginAdapter(vaadinConfig,
+                applicationModel, appModule);
+    }
+
+    /**
+     * Creates a new instance of the VaadinPlugin based on the provided
+     * configuration and application model. If necessary, it attempts to load
+     * workspace information for the plugin.
+     *
+     * @param vaadinConfig
+     *            the Vaadin build time configuration.
+     * @param applicationModel
+     *            the application model representing the current application.
+     * @param outputTarget
+     *            the target directory for output operations.
+     * @return an instance of VaadinPlugin initialized with the given
+     *         parameters.
+     * @throws BuildException
+     *             if workspace information cannot be loaded or an error occurs
+     *             during the process.
+     */
+    public static VaadinPlugin of(VaadinBuildTimeConfig vaadinConfig,
+            ApplicationModel applicationModel, Path outputTarget)
+            throws BuildException {
+        WorkspaceModule module = applicationModel.getApplicationModule();
+        if (module == null) {
+            try {
+                module = WorkspaceInfo.load(outputTarget);
+            } catch (Exception e) {
+                throw new BuildException(
+                        "Cannot load workspace information for Vaadin plugin",
+                        e, List.of());
+            }
+        }
+        return new VaadinPlugin(vaadinConfig, applicationModel, module);
+    }
+
+    /**
+     * Checks that node and npm tools are installed and creates or updates
+     * `package.json` and the frontend build tool configuration files.
+     * <p>
+     * </p>
+     * Copies frontend resources available inside `.jar` dependencies to
+     * `node_modules` when building a jar package.
+     *
+     * @throws BuildException
+     *             if any error occurs.
+     */
+    public void prepareFrontend() throws BuildException {
+        // propagate info via System properties and token file
+        BuildFrontendUtil.propagateBuildInfo(pluginAdapter);
+
+        try {
+            BuildFrontendUtil.prepareFrontend(pluginAdapter);
+        } catch (Exception exception) {
+            throw new BuildException("Could not execute prepare-frontend goal.",
+                    exception, List.of());
+        }
+    }
+
+    /**
+     * Builds the frontend bundle.
+     * <p>
+     * </p>
+     * It performs the following actions when creating a package:
+     * <ul>
+     * <li>Update {@link Constants#PACKAGE_JSON} file with the
+     * {@link NpmPackage} annotations defined in the classpath,</li>
+     * <li>Copy resource files used by flow from `.jar` files to the
+     * `node_modules` folder</li>
+     * <li>Install dependencies by running <code>npm install</code></li>
+     * <li>Update the {@link FrontendUtils#IMPORTS_NAME} file imports with the
+     * {@link JsModule} {@link Theme} and {@link JavaScript} annotations defined
+     * in the classpath,</li>
+     * <li>Update {@link FrontendUtils#VITE_CONFIG} file.</li>
+     * </ul>
+     *
+     * @param emitter
+     *            generated files emitter.
+     * @throws BuildException
+     *             if any error occurs.
+     */
+    public void buildFrontend(BiConsumer<String, byte[]> emitter)
+            throws BuildException {
+        long start = System.nanoTime();
+
+        FrontendDependenciesScanner frontendDependencies = createFrontendScanner();
+        try {
+            BuildFrontendUtil.runNodeUpdater(pluginAdapter,
+                    frontendDependencies);
+        } catch (ExecutionFailedException | URISyntaxException exception) {
+            throw new BuildException("Could not execute build-frontend goal",
+                    exception, List.of());
+        }
+
+        if (pluginAdapter.generateBundle()
+                && BundleValidationUtil.needsBundleBuild(
+                        pluginAdapter.servletResourceOutputDirectory())) {
+            try {
+                BuildFrontendUtil.runFrontendBuild(pluginAdapter);
+            } catch (URISyntaxException | TimeoutException exception) {
+                throw new BuildException(exception.getMessage(), exception,
+                        List.of());
+            }
+        }
+        LicenseChecker.setStrictOffline(true);
+        boolean licenseRequired;
+        boolean commercialBannerRequired;
+        try {
+            licenseRequired = BuildFrontendUtil.validateLicenses(pluginAdapter,
+                    frontendDependencies);
+            commercialBannerRequired = false;
+        } catch (MissingLicenseKeyException ex) {
+            licenseRequired = true;
+            commercialBannerRequired = true;
+            pluginAdapter.logInfo(ex.getMessage());
+        }
+
+        BuildFrontendUtil.updateBuildFile(pluginAdapter, licenseRequired,
+                commercialBannerRequired);
+
+        long ms = (System.nanoTime() - start) / 1000000;
+        pluginAdapter.logInfo("Build frontend completed in " + ms + " ms.");
+
+        emitGeneratedFiles(emitter);
+    }
+
+    private void emitGeneratedFiles(BiConsumer<String, byte[]> emitter)
+            throws BuildException {
+        Path vaadinMetaInfDir = pluginAdapter.servletResourceOutputDirectory()
+                .toPath();
+        Path buildFolder = pluginAdapter.buildDir();
+
+        if (Files.exists(vaadinMetaInfDir)) {
+            try (var stream = Files.walk(vaadinMetaInfDir)) {
+                stream.filter(Files::isRegularFile).forEach(filePath -> {
+                    try {
+                        // Calculate relative path from target/classes
+                        Path relativePath = buildFolder.relativize(filePath);
+                        byte[] content = Files.readAllBytes(filePath);
+                        emitter.accept(
+                                relativePath.toString().replace('\\', '/'),
+                                content);
+
+                        pluginAdapter.logDebug(
+                                "Added Vaadin resource: " + relativePath);
+                    } catch (IOException e) {
+                        pluginAdapter
+                                .logWarn("Failed to read Vaadin resource file: "
+                                        + filePath, e);
+                    }
+                });
+
+                pluginAdapter.logInfo(
+                        "Added Vaadin frontend resources from META-INF/VAADIN to artifact");
+
+            } catch (IOException e) {
+                throw new BuildException(
+                        "Failed to scan Vaadin resources directory", e,
+                        List.of());
+            }
+        } else {
+            pluginAdapter.logInfo(
+                    "No META-INF/VAADIN directory found, skipping resource addition");
+        }
+    }
+
+    /**
+     * Cleans up generated frontend files if the corresponding configuration
+     * setting is enabled. The process involves creating a new cleaning task
+     * with specific options derived from the plugin adapter's configuration and
+     * executing it. If an error occurs during the execution of the clean task,
+     * it is logged for debugging purposes.
+     * <p>
+     * The cleanup operation ensures the following: - Deletes the generated
+     * frontend files in the `node_modules` folder. - Utilizes the directory
+     * configurations such as frontend directory, npm folder, and generated
+     * TypeScript folder to locate the files. - Makes use of the
+     * `TaskCleanFrontendFiles` for cleanup operations.
+     */
+    public void clean() {
+        if (pluginAdapter.cleanFrontendFiles()) {
+            Options options = new Options(null, pluginAdapter.getClassFinder(),
+                    pluginAdapter.npmFolder())
+                    .withFrontendDirectory(pluginAdapter.frontendDirectory())
+                    .withFrontendGeneratedFolder(
+                            pluginAdapter.generatedTsFolder());
+            TaskCleanFrontendFiles cleanTask = new TaskCleanFrontendFiles(
+                    options);
+            try {
+                cleanTask.execute();
+            } catch (ExecutionFailedException exception) {
+                pluginAdapter.logError("Error cleaning frontend files",
+                        exception);
+            }
+        }
+    }
+
+    private FrontendDependenciesScanner createFrontendScanner() {
+        boolean reactEnabled = pluginAdapter.isReactEnabled()
+                && FrontendUtils.isReactRouterRequired(
+                        BuildFrontendUtil.getFrontendDirectory(pluginAdapter));
+        ClassFinder classFinder = pluginAdapter.getClassFinder();
+        FeatureFlags featureFlags = new FeatureFlags(
+                pluginAdapter.createLookup(classFinder));
+        if (pluginAdapter.javaResourceFolder() != null) {
+            featureFlags
+                    .setPropertiesLocation(pluginAdapter.javaResourceFolder());
+        }
+        return new FrontendDependenciesScanner.FrontendDependenciesScannerFactory()
+                .createScanner(!pluginAdapter.optimizeBundle(), classFinder,
+                        pluginAdapter.generateEmbeddableWebComponents(),
+                        featureFlags, reactEnabled);
+    }
+
+}

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinPlugin.java
@@ -62,11 +62,14 @@ public final class VaadinPlugin {
      *            the Vaadin build configuration.
      * @param applicationModel
      *            the application model.
+     * @param workspaceModule
+     *            the workspace module.
      */
     private VaadinPlugin(VaadinBuildTimeConfig vaadinConfig,
-            ApplicationModel applicationModel, WorkspaceModule appModule) {
+            ApplicationModel applicationModel,
+            WorkspaceModule workspaceModule) {
         this.pluginAdapter = new QuarkusPluginAdapter(vaadinConfig,
-                applicationModel, appModule);
+                applicationModel, workspaceModule);
     }
 
     /**

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfo.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfo.java
@@ -1,0 +1,115 @@
+package com.vaadin.quarkus.deployment.vaadinplugin;
+
+import com.vaadin.flow.internal.JacksonUtils;
+import io.quarkus.bootstrap.workspace.*;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The WorkspaceInfo class provides methods for saving and loading project
+ * workspace information related to a quarkus application. This information
+ * includes details about the module's directory, build directory, source
+ * directories, and resource directories. The class uses JSON-based
+ * serialization and deserialization for the persistence of workspace
+ * information.
+ */
+class WorkspaceInfo {
+
+    private record ProjectInfo(String groupId, String artifactId,
+            String version, String moduleDir, String buildDir,
+            List<SourceDirInfo> sourceDirs, List<SourceDirInfo> resourceDirs) {
+
+        WorkspaceModuleId moduleId() {
+            return WorkspaceModuleId.of(groupId, artifactId, version);
+        }
+    }
+
+    private record SourceDirInfo(String dir, String outputDir) {
+        SourceDirInfo(SourceDir sourceDir) {
+            this(sourceDir.getDir().toFile().getAbsolutePath(),
+                    sourceDir.getOutputDir().toFile().getAbsolutePath());
+        }
+    }
+
+    /**
+     * Saves workspace information of the given module to the specified working
+     * directory.
+     *
+     * @param module
+     *            the workspace module containing the information to be saved
+     * @param workDir
+     *            the directory where the workspace information will be written
+     *            to
+     * @throws Exception
+     *             if an error occurs while writing the workspace information
+     */
+    static void save(WorkspaceModule module, Path workDir) throws Exception {
+        Path projectInfoFile = resolveProjectInfoFile(workDir);
+        var info = collectWorkspaceInfo(module);
+        Files.writeString(projectInfoFile,
+                JacksonUtils.getMapper().writeValueAsString(info),
+                StandardOpenOption.CREATE);
+    }
+
+    /**
+     * Loads a {@code WorkspaceModule} instance from the specified working
+     * directory. If the project information file exists, it reads the project
+     * details and constructs a {@code WorkspaceModule} object. If the file does
+     * not exist, it returns {@code null}.
+     *
+     * @param workDir
+     *            the directory where the project information file is located
+     * @return a {@code WorkspaceModule} object built from the project
+     *         information file, or {@code null} if the file does not exist
+     * @throws Exception
+     *             if an error occurs while reading or parsing the project
+     *             information file
+     */
+    static WorkspaceModule load(Path workDir) throws Exception {
+        Path projectInfoFile = resolveProjectInfoFile(workDir);
+        if (Files.exists(projectInfoFile)) {
+            var info = JacksonUtils.getMapper()
+                    .readValue(projectInfoFile.toFile(), ProjectInfo.class);
+            return WorkspaceModule.builder().setModuleId(info.moduleId())
+                    .setModuleDir(Path.of(info.moduleDir()))
+                    .setBuildDir(Path.of(info.buildDir()))
+                    .addArtifactSources(new DefaultArtifactSources(
+                            ArtifactSources.MAIN,
+                            info.sourceDirs.stream()
+                                    .map(d -> SourceDir.of(Path.of(d.dir()),
+                                            Path.of(d.outputDir())))
+                                    .toList(),
+                            info.resourceDirs.stream()
+                                    .map(d -> SourceDir.of(Path.of(d.dir()),
+                                            Path.of(d.outputDir())))
+                                    .toList()))
+                    .build();
+        }
+        return null;
+    }
+
+    private static Path resolveProjectInfoFile(Path workDir) {
+        return workDir.resolve("vaadin-plugin-project-info.txt");
+    }
+
+    private static ProjectInfo collectWorkspaceInfo(WorkspaceModule module) {
+        List<SourceDirInfo> sourceDirs = null;
+        List<SourceDirInfo> resourceDirs = null;
+        if (module.hasMainSources()) {
+            sourceDirs = module.getMainSources().getSourceDirs().stream()
+                    .map(SourceDirInfo::new).collect(Collectors.toList());
+            resourceDirs = module.getMainSources().getResourceDirs().stream()
+                    .map(SourceDirInfo::new).collect(Collectors.toList());
+        }
+        WorkspaceModuleId moduleId = module.getId();
+        return new ProjectInfo(moduleId.getGroupId(), moduleId.getArtifactId(),
+                moduleId.getVersion(), module.getModuleDir().getAbsolutePath(),
+                module.getBuildDir().getAbsolutePath(), sourceDirs,
+                resourceDirs);
+    }
+
+}

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfo.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.quarkus.deployment.vaadinplugin;
 
 import com.vaadin.flow.internal.JacksonUtils;

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfoCollector.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfoCollector.java
@@ -50,7 +50,7 @@ public class WorkspaceInfoCollector implements CodeGenProvider {
             return false;
         }
         if (!config.getOptionalValue("vaadin.build.enabled", Boolean.class)
-                .orElse(false)) {
+                .orElse(true)) {
             LOGGER.info(
                     "Workspace information for Vaadin embedded plugin not collected because Vaadin embedded plugin is disabled");
             return false;

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfoCollector.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfoCollector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.vaadin.quarkus.deployment.vaadinplugin;
 
 import io.quarkus.bootstrap.model.ApplicationModel;

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfoCollector.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/WorkspaceInfoCollector.java
@@ -1,0 +1,82 @@
+package com.vaadin.quarkus.deployment.vaadinplugin;
+
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.bootstrap.prebuild.CodeGenException;
+import io.quarkus.bootstrap.workspace.WorkspaceModule;
+import io.quarkus.deployment.CodeGenContext;
+import io.quarkus.deployment.CodeGenProvider;
+import org.eclipse.microprofile.config.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Workaround to collect workspace info when it is not available at build time.
+ * <p>
+ * During a normal build, workspace information is available only if the
+ * {@code quarkus.bootstrap.workspace-discovery} property is set to
+ * {@code true}. This class gets executed during the code generation phase, so
+ * it has access to the workspace details and can persist them to make them
+ * available to subsequent build steps.
+ */
+public class WorkspaceInfoCollector implements CodeGenProvider {
+
+    private static final Logger LOGGER = LoggerFactory
+            .getLogger(WorkspaceInfoCollector.class);
+    private WorkspaceModule module;
+
+    @Override
+    public String providerId() {
+        return "vaadin-plugin-workspace-info";
+    }
+
+    @Override
+    public String inputDirectory() {
+        return "";
+    }
+
+    @Override
+    public void init(ApplicationModel model, Map<String, String> properties) {
+        module = model.getApplicationModule();
+    }
+
+    @Override
+    public boolean shouldRun(Path sourceDir, Config config) {
+        if (module == null) {
+            LOGGER.debug(
+                    "Workspace information for Vaadin embedded plugin not collected because module details are not available");
+            return false;
+        }
+        if (!config.getOptionalValue("vaadin.build.enabled", Boolean.class)
+                .orElse(false)) {
+            LOGGER.info(
+                    "Workspace information for Vaadin embedded plugin not collected because Vaadin embedded plugin is disabled");
+            return false;
+        }
+        if (config.getOptionalValue("quarkus.bootstrap.workspace-discovery",
+                Boolean.class).orElse(false)) {
+            LOGGER.debug(
+                    "Workspace information for Vaadin embedded plugin not collected because workspace information already available at build time");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean trigger(CodeGenContext context) throws CodeGenException {
+        if (module != null) {
+            LOGGER.info("Collecting workspace information for Vaadin plugin");
+            try {
+                WorkspaceInfo.save(module, context.workDir());
+            } catch (Exception e) {
+                throw new CodeGenException(
+                        "Failed to store workspace information for Vaadin plugin",
+                        e);
+            }
+        }
+        return false;
+    }
+
+}

--- a/deployment/src/main/resources/META-INF/services/io.quarkus.deployment.CodeGenProvider
+++ b/deployment/src/main/resources/META-INF/services/io.quarkus.deployment.CodeGenProvider
@@ -1,0 +1,18 @@
+#
+# Copyright 2024 Marco Collovati, Dario Götze
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+com.vaadin.quarkus.deployment.vaadinplugin.WorkspaceInfoCollector

--- a/deployment/src/main/resources/META-INF/services/io.quarkus.deployment.CodeGenProvider
+++ b/deployment/src/main/resources/META-INF/services/io.quarkus.deployment.CodeGenProvider
@@ -1,18 +1,17 @@
 #
-# Copyright 2024 Marco Collovati, Dario Götze
+# Copyright 2000-2025 Vaadin Ltd.
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
 #
 
 com.vaadin.quarkus.deployment.vaadinplugin.WorkspaceInfoCollector

--- a/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/VaadinExtensionCodestartTest.java
+++ b/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/VaadinExtensionCodestartTest.java
@@ -48,7 +48,6 @@ public class VaadinExtensionCodestartTest {
                     assertSoftly(soft -> {
                         assertThatHasVaadinBom(pom, soft);
                         assertThatHasVaadinQuarkusExtension(pom, soft);
-                        assertThatHasProductionProfile(pom, soft);
                     });
                 });
     }

--- a/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/VaadinExtensionCodestartTest.java
+++ b/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/VaadinExtensionCodestartTest.java
@@ -9,7 +9,6 @@ import org.apache.maven.model.io.DefaultModelReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.vaadin.flow.quarkus.it.CodestartTestUtils.assertThatHasProductionProfile;
 import static com.vaadin.flow.quarkus.it.CodestartTestUtils.assertThatHasVaadinBom;
 import static com.vaadin.flow.quarkus.it.CodestartTestUtils.assertThatHasVaadinQuarkusExtension;
 import static io.quarkus.devtools.testing.SnapshotTesting.checkContains;

--- a/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/VaadinExtensionPreReleaseCodestartTest.java
+++ b/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/VaadinExtensionPreReleaseCodestartTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static com.vaadin.flow.quarkus.it.CodestartTestUtils.assertThatHasPreReleaseRepositories;
-import static com.vaadin.flow.quarkus.it.CodestartTestUtils.assertThatHasProductionProfile;
 import static com.vaadin.flow.quarkus.it.CodestartTestUtils.assertThatHasVaadinBom;
 import static com.vaadin.flow.quarkus.it.CodestartTestUtils.assertThatHasVaadinQuarkusExtension;
 import static io.quarkus.devtools.testing.SnapshotTesting.checkContains;
@@ -47,7 +46,6 @@ public class VaadinExtensionPreReleaseCodestartTest {
                     assertSoftly(soft -> {
                         assertThatHasVaadinBom(pom, soft);
                         assertThatHasVaadinQuarkusExtension(pom, soft);
-                        assertThatHasProductionProfile(pom, soft);
                         assertThatHasPreReleaseRepositories(pom, soft);
                     });
                 });

--- a/integration-tests/common-test-code/src/main/resources/application.properties
+++ b/integration-tests/common-test-code/src/main/resources/application.properties
@@ -5,3 +5,6 @@ quarkus.index-dependency.lumo.group-id=com.vaadin
 quarkus.index-dependency.lumo.artifact-id=vaadin-lumo-theme
 quarkus.index-dependency.addon-without-jandex.group-id=com.vaadin
 quarkus.index-dependency.addon-without-jandex.artifact-id=test-addon-without-jandex
+
+
+vaadin.build.enabled=false

--- a/integration-tests/embedded-plugin/pom.xml
+++ b/integration-tests/embedded-plugin/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vaadin</groupId>
+        <artifactId>vaadin-quarkus-integration-tests</artifactId>
+        <version>3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>vaadin-quarkus-embedded-plugin-tests</artifactId>
+    <name>Vaadin Quarkus - Integration Tests with embedded Vaadin plugin</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-dnd</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-react</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>reusable-theme</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>test-addon-without-jandex</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>test-addon-with-jandex</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>custom-websockets</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-jandex</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-quarkus</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-websockets</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-html-components-testbench</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-test-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/../common-test-code/src/main/java</sourceDirectory>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/../common-test-code/src/main/resources</directory>
+                <excludes>
+                    <exclude>application.properties</exclude>
+                </excludes>
+            </resource>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
+        <testSourceDirectory>${project.basedir}/../common-test-code/src/test/java</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/integration-tests/embedded-plugin/src/main/resources/application.properties
+++ b/integration-tests/embedded-plugin/src/main/resources/application.properties
@@ -5,6 +5,3 @@ quarkus.index-dependency.lumo.group-id=com.vaadin
 quarkus.index-dependency.lumo.artifact-id=vaadin-lumo-theme
 quarkus.index-dependency.addon-without-jandex.group-id=com.vaadin
 quarkus.index-dependency.addon-without-jandex.artifact-id=test-addon-without-jandex
-
-
-vaadin.build.enabled=true

--- a/integration-tests/embedded-plugin/src/main/resources/application.properties
+++ b/integration-tests/embedded-plugin/src/main/resources/application.properties
@@ -1,0 +1,10 @@
+quarkus.http.test-port=8888
+quarkus.http.host=0.0.0.0
+
+quarkus.index-dependency.lumo.group-id=com.vaadin
+quarkus.index-dependency.lumo.artifact-id=vaadin-lumo-theme
+quarkus.index-dependency.addon-without-jandex.group-id=com.vaadin
+quarkus.index-dependency.addon-without-jandex.artifact-id=test-addon-without-jandex
+
+
+vaadin.build.enabled=true

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -26,6 +26,7 @@
         <!-- Run common-test-code in dev and prod modes -->
         <module>production</module>
         <module>development</module>
+        <module>embedded-plugin</module>
 
         <!-- Codestarts tests -->
         <module>codestarts</module>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -65,9 +65,6 @@
                         <configuration>
                             <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
                             </deployment>
-                            <conditionalDevDependencies>
-                                <dependency>com.vaadin:vaadin-dev:25.0-SNAPSHOT</dependency>
-                            </conditionalDevDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -65,6 +65,9 @@
                         <configuration>
                             <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
                             </deployment>
+                            <conditionalDevDependencies>
+                                <dependency>com.vaadin:vaadin-dev:25.0-SNAPSHOT</dependency>
+                            </conditionalDevDependencies>
                         </configuration>
                     </execution>
                 </executions>

--- a/runtime/src/main/codestarts/quarkus/flow-codestart/base/pom.xml.tpl.qute
+++ b/runtime/src/main/codestarts/quarkus/flow-codestart/base/pom.xml.tpl.qute
@@ -31,6 +31,12 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>vaadin-dev</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
@@ -38,31 +44,6 @@
         </dependency>
         -->
     </dependencies>
-
-    <profiles>
-        <profile>
-            <!-- Vaadin Production mode is activated using -Pproduction -->
-            <id>production</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-maven-plugin</artifactId>
-                        <version>$\{vaadin.version\}</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>prepare-frontend</goal>
-                                    <goal>build-frontend</goal>
-                                </goals>
-                                <phase>compile</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     {#if !vaadinVersion.matches("^\\d+\\.\\d+\.\\d+$") }
     {! Vaadin SNAPSHOT or pre-release, this section is added only when testing !}


### PR DESCRIPTION
Add comprehensive Vaadin build tooling integration that embeds the Vaadin
frontend build process directly into the Quarkus build lifecycle, eliminating
the need for external Maven/Gradle plugin configuration.

Configuration is available through `vaadin.build.*` properties with
comprehensive options for customizing the build process.

The result of the changes is that an application using Vaadin Quarkus
extension does not need a specific production profile to generate
a production build.

CAVEATS:
- The plugin requires information about the project to correctly build
fronted resources; unfortunately the information are not available
at build time unless the quarkus.bootstrap.workspace-discovery flag
is activate. To overcome to this limitation, the extension provides
a CodeGenProvider that collects the required info when executed by
quarkus generate-code and generate-code-tests goals and writes them
into the build folder to be able to read them again in the build steps.

RelatedTo: vaadin/flow#22440