### PR TITLE
fix: prevent failure when analyzing classes in default package

### DIFF
--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusNativeProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusNativeProcessor.java
@@ -252,7 +252,7 @@ public class VaadinQuarkusNativeProcessor {
         }
     }
 
-    @BuildStep
+    @BuildStep(onlyIf = IsNativeBuild.class)
     void vaadinNativeSupport(CombinedIndexBuildItem combinedIndex,
             BuildProducer<RuntimeInitializedPackageBuildItem> runtimeInitializedPackage,
             BuildProducer<NativeImageResourcePatternsBuildItem> nativeImageResource,
@@ -350,10 +350,11 @@ public class VaadinQuarkusNativeProcessor {
     private Stream<ClassInfo> collectClassesInPackage(IndexView index,
             String basePackage, boolean recursive) {
         Predicate<ClassInfo> predicate = recursive
-                ? classInfo -> classInfo.name().packagePrefix()
-                        .startsWith(basePackage)
-                : classInfo -> classInfo.name().packagePrefix()
-                        .equals(basePackage);
+                ? classInfo -> classInfo.name().packagePrefix() != null
+                        && classInfo.name().packagePrefix()
+                                .startsWith(basePackage)
+                : classInfo -> classInfo.name().packagePrefix() != null
+                        && classInfo.name().packagePrefix().equals(basePackage);
         return index.getKnownClasses().stream().filter(predicate);
     }
 

--- a/deployment/src/test/java/ClassInDefaultPackage.java
+++ b/deployment/src/test/java/ClassInDefaultPackage.java
@@ -1,0 +1,18 @@
+/*
+ *  Copyright 2000-2025 Vaadin Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+
+public class ClassInDefaultPackage {
+}

--- a/deployment/src/test/java/com/vaadin/flow/quarkus/test/NativeBuildClassesInDefaultPackageTest.java
+++ b/deployment/src/test/java/com/vaadin/flow/quarkus/test/NativeBuildClassesInDefaultPackageTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright 2000-2025 Vaadin Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ *  use this file except in compliance with the License. You may obtain a copy of
+ *  the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations under
+ *  the License.
+ */
+package com.vaadin.flow.quarkus.test;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class NativeBuildClassesInDefaultPackageTest {
+
+    // Start unit test with your extension loaded
+    @RegisterExtension
+    static final QuarkusUnitTest unitTest = new QuarkusUnitTest()
+            .setArchiveProducer(() -> ShrinkWrap.create(JavaArchive.class)
+                    .addClass(loadClassFromDefaultPackage()))
+            .overrideConfigKey("quarkus.package.type", "native");
+
+    @Test
+    public void classesInDefaultPackage_vaadinNativeSupport_scanShouldNotFail() {
+        Assertions.assertTrue(true,
+                "Quarkus build should not fail with classes in default package");
+    }
+
+    private static Class<?> loadClassFromDefaultPackage() {
+        try {
+            return Class.forName("ClassInDefaultPackage");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
For native support, the extension inspects the Jandex index to find all classes under specified packages.
However, the scan fails with an NPE if the index contains classes from the default package.
This fix adds a null check to prevent the NPE and also marks the vaadinNativeSupport build step to only be executed during native build.

Fixes #222