### PR TITLE
fix: make instantiator lookup all defined VaadinServiceInitListener beans

### DIFF
--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusInstantiator.java
@@ -15,10 +15,11 @@
  */
 package com.vaadin.quarkus;
 
+import jakarta.enterprise.inject.spi.BeanManager;
+
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
-import jakarta.enterprise.inject.spi.BeanManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,7 +120,13 @@ public class QuarkusInstantiator implements Instantiator {
 
     @Override
     public Stream<VaadinServiceInitListener> getServiceInitListeners() {
-        return Stream.concat(delegate.getServiceInitListeners(),
+
+        final BeanLookup<VaadinServiceInitListener> lookup = new BeanLookup<>(
+                getBeanManager(), VaadinServiceInitListener.class,
+                VaadinServiceEnabled.Literal.INSTANCE);
+        return Stream.concat(
+                Stream.concat(delegate.getServiceInitListeners(),
+                        lookup.lookupAll()),
                 Stream.of(event -> getBeanManager().getEvent().fire(event)));
     }
 

--- a/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorTest.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/QuarkusInstantiatorTest.java
@@ -12,22 +12,13 @@ import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InterceptorBinding;
 import jakarta.interceptor.InvocationContext;
 import jakarta.servlet.ServletException;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Locale;
-
-import com.vaadin.flow.component.Component;
-import com.vaadin.flow.component.Tag;
-import com.vaadin.flow.di.Instantiator;
-import com.vaadin.flow.i18n.I18NProvider;
-import com.vaadin.flow.server.ServiceInitEvent;
-import com.vaadin.flow.server.VaadinService;
-import com.vaadin.flow.server.auth.MenuAccessControl;
-import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
-import com.vaadin.quarkus.context.ServiceUnderTestContext;
 
 import io.quarkus.arc.Unremovable;
 import io.quarkus.test.junit.QuarkusTest;
@@ -37,6 +28,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+import com.vaadin.flow.di.Instantiator;
+import com.vaadin.flow.i18n.I18NProvider;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.flow.server.auth.MenuAccessControl;
+import com.vaadin.quarkus.annotation.VaadinServiceEnabled;
+import com.vaadin.quarkus.context.ServiceUnderTestContext;
 
 @QuarkusTest
 public class QuarkusInstantiatorTest {
@@ -150,6 +152,23 @@ public class QuarkusInstantiatorTest {
 
     }
 
+    @Singleton
+    @VaadinServiceEnabled
+    public static class CdiBeanServiceInitListener
+            implements VaadinServiceInitListener {
+
+        ServiceInitEvent event;
+
+        public void serviceInit(ServiceInitEvent event) {
+            this.event = event;
+        }
+
+        public ServiceInitEvent getEvent() {
+            return event;
+        }
+
+    }
+
     @Inject
     private BeanManager beanManager;
 
@@ -196,12 +215,11 @@ public class QuarkusInstantiatorTest {
                 .assertTrue(menuAccessControl instanceof TestMenuAccessControl);
     }
 
-    /*
-     * @Test public void
-     * getServiceInitListeners_javaSPIListenerExists_containsJavaSPIListener() {
-     * Assertions.assertTrue(instantiator.getServiceInitListeners().anyMatch(
-     * listener -> listener instanceof JavaSPIVaadinServiceInitListener)); }
-     */
+    @Test
+    public void getServiceInitListeners_CDIBeanListenerExists_containsCDIBeanListener() {
+        Assertions.assertTrue(instantiator.getServiceInitListeners().anyMatch(
+                listener -> listener instanceof CdiBeanServiceInitListener));
+    }
 
     @Test
     public void getServiceInitListeners_eventFired_cdiObserverCalled() {


### PR DESCRIPTION
Fixes #234
