### PR TITLE
fix: add reflection hints for Dependency class

### DIFF
--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusNativeProcessor.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/VaadinQuarkusNativeProcessor.java
@@ -34,6 +34,7 @@ import com.vaadin.flow.router.RouterLayout;
 import com.vaadin.flow.server.auth.AccessDeniedErrorRouter;
 import com.vaadin.flow.server.menu.AvailableViewInfo;
 import com.vaadin.flow.server.menu.RouteParamType;
+import com.vaadin.flow.shared.ui.Dependency;
 import com.vaadin.quarkus.deployment.nativebuild.AtmospherePatches;
 import com.vaadin.quarkus.graal.AtmosphereDeferredInitializerRecorder;
 import com.vaadin.quarkus.graal.DelayedSchedulerExecutorsFactory;
@@ -279,7 +280,8 @@ public class VaadinQuarkusNativeProcessor {
                 .builder(AvailableViewInfo.class,
                         AvailableViewInfo.DetailSerializer.class,
                         AvailableViewInfo.DetailDeserializer.class,
-                        MenuData.class, RouteParamType.class, Id.class)
+                        MenuData.class, RouteParamType.class, Id.class,
+                        Dependency.class)
                 .constructors().methods().fields().build());
 
         Set<ClassInfo> classes = new HashSet<>();


### PR DESCRIPTION
In previous Flow versions, Dependency class had a toJson method that created an elemental JsonObject to be sent to the client as JSON. However, the method has been removed and replaced by Jackson serialization. This causes wrong JSON serialization in native executables because reflection is required but metadata is not stored for the Dependency class.

This change adds the missing reflection hint for the Dependency class.

Fixes #239