### PR TITLE
fix: preserve route-scoped beans for proxied views (#277) (CP: 2.2)

### DIFF
--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/instantiator/UselessInterceptor.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/instantiator/UselessInterceptor.java
@@ -1,8 +1,15 @@
 package com.vaadin.flow.quarkus.it.instantiator;
 
-import io.quarkus.arc.Unremovable;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
 
-@Unremovable
+@Interceptor
 @Useless
 public class UselessInterceptor {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed();
+    }
 }

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/MainLayout.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/MainLayout.java
@@ -29,6 +29,7 @@ public class MainLayout extends Div implements RouterLayout {
     public static final String INVALID = "invalid";
     public static final String PARENT_NO_OWNER = "parent-no-owner";
     public static final String CHILD_NO_OWNER = "child-no-owner";
+    public static final String PROXIED = "proxied-route-scope";
 
     private Span uiIdLabel;
 
@@ -36,7 +37,8 @@ public class MainLayout extends Div implements RouterLayout {
         add(new RouterLink(PRESERVE, PreserveOnRefreshView.class),
                 new RouterLink(INVALID, InvalidView.class),
                 new RouterLink(PARENT_NO_OWNER, ParentNoOwnerView.class),
-                new RouterLink(CHILD_NO_OWNER, ChildNoOwnerView.class));
+                new RouterLink(CHILD_NO_OWNER, ChildNoOwnerView.class),
+                new RouterLink(PROXIED, ProxiedView.class));
     }
 
     @Override

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/ProxiedView.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/ProxiedView.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.quarkus.it.routecontext;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.quarkus.it.instantiator.Useless;
+import com.vaadin.flow.router.AfterNavigationEvent;
+import com.vaadin.flow.router.AfterNavigationObserver;
+import com.vaadin.flow.router.BeforeEnterEvent;
+import com.vaadin.flow.router.BeforeEnterObserver;
+import com.vaadin.flow.router.Route;
+import com.vaadin.quarkus.annotation.RouteScopeOwner;
+import com.vaadin.quarkus.annotation.RouteScoped;
+
+@Route(value = "proxied-route-scope", layout = MainLayout.class)
+@RouteScoped
+// Interceptor binding causes Arc to create a proxy subclass for this view
+@Useless
+public class ProxiedView extends AbstractCountedView
+        implements BeforeEnterObserver, AfterNavigationObserver {
+
+    public static final String PRESENTER_LABEL = "PRESENTER_STATUS";
+
+    @Inject
+    Event<String> viewEvent;
+
+    @Inject
+    @RouteScopeOwner(ProxiedView.class)
+    ProxiedViewPresenter presenter;
+
+    private Span presenterLabel;
+
+    @PostConstruct
+    private void init() {
+        presenterLabel = new Span();
+        presenterLabel.setId(PRESENTER_LABEL);
+        add(new Span("PROXIED"), presenterLabel);
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        viewEvent.fire("beforeEnter");
+    }
+
+    @Override
+    public void afterNavigation(AfterNavigationEvent event) {
+        viewEvent.fire("afterNavigation");
+        presenterLabel.setText(presenter.getLastEvent());
+    }
+}

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/ProxiedViewPresenter.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/ProxiedViewPresenter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.flow.quarkus.it.routecontext;
+
+import jakarta.enterprise.event.Observes;
+
+import com.vaadin.quarkus.annotation.RouteScopeOwner;
+import com.vaadin.quarkus.annotation.RouteScoped;
+
+@RouteScoped
+@RouteScopeOwner(ProxiedView.class)
+public class ProxiedViewPresenter extends AbstractCountedBean {
+
+    private String lastEvent = "";
+
+    public void onEvent(@Observes String eventName) {
+        lastEvent = eventName;
+    }
+
+    public String getLastEvent() {
+        return lastEvent;
+    }
+}

--- a/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/RootView.java
+++ b/integration-tests/common-test-code/src/main/java/com/vaadin/flow/quarkus/it/routecontext/RootView.java
@@ -33,6 +33,7 @@ public class RootView extends AbstractCountedView {
     public static final String POSTPONE = "postpone";
     public static final String EVENT = "event";
     public static final String ERROR = "ERROR";
+    public static final String PROXIED = "proxied-route-scope";
 
     @PostConstruct
     private void init() {
@@ -41,7 +42,8 @@ public class RootView extends AbstractCountedView {
                 new Div(new RouterLink(REROUTE, RerouteView.class)),
                 new Div(new RouterLink(POSTPONE, PostponeView.class)),
                 new Div(new RouterLink(EVENT, EventView.class)),
-                new Div(new RouterLink(ERROR, ErrorView.class)));
+                new Div(new RouterLink(ERROR, ErrorView.class)),
+                new Div(new RouterLink(PROXIED, ProxiedView.class)));
     }
 
 }

--- a/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/RouteContextIT.java
+++ b/integration-tests/common-test-code/src/test/java/com/vaadin/flow/quarkus/it/RouteContextIT.java
@@ -39,6 +39,8 @@ import com.vaadin.flow.quarkus.it.routecontext.MainLayout;
 import com.vaadin.flow.quarkus.it.routecontext.MasterView;
 import com.vaadin.flow.quarkus.it.routecontext.PostponeView;
 import com.vaadin.flow.quarkus.it.routecontext.PreserveOnRefreshBean;
+import com.vaadin.flow.quarkus.it.routecontext.ProxiedView;
+import com.vaadin.flow.quarkus.it.routecontext.ProxiedViewPresenter;
 import com.vaadin.flow.quarkus.it.routecontext.RerouteView;
 import com.vaadin.flow.quarkus.it.routecontext.RootView;
 
@@ -291,6 +293,18 @@ public class RouteContextIT extends AbstractCdiIT {
         assertConstructed(ErrorBean2.class, 1);
         assertDestroyed(ErrorBean1.class, 0);
         assertDestroyed(ErrorBean2.class, 0);
+    }
+
+    @Test
+    public void proxiedView_presenterObservesEventsAfterNavigation()
+            throws IOException {
+        follow(RootView.PROXIED);
+        // The presenter should have observed the "afterNavigation" event
+        // fired by the view in its afterNavigation() callback
+        assertTextEquals("afterNavigation", ProxiedView.PRESENTER_LABEL);
+        // Presenter bean should be constructed and NOT destroyed
+        assertConstructed(ProxiedViewPresenter.class, 1);
+        assertDestroyed(ProxiedViewPresenter.class, 0);
     }
 
     private void assertRootViewIsDisplayed() {

--- a/runtime/src/main/java/com/vaadin/quarkus/context/RouteScopedContext.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/context/RouteScopedContext.java
@@ -35,6 +35,7 @@ import io.quarkus.arc.Unremovable;
 import com.vaadin.flow.component.ComponentUtil;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
+import com.vaadin.flow.di.Instantiator;
 import com.vaadin.flow.router.AfterNavigationEvent;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.RouterLayout;
@@ -67,24 +68,28 @@ public class RouteScopedContext extends AbstractContext {
             return super.newContextualStorage(key);
         }
 
-
         /**
-         * <a href="https://stackoverflow.com/questions/48902847/cdi-observer-condition-in-dependent-bean">...</a>
-         * <a href="https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#conditional_observer_methods">...</a>
+         * <a href=
+         * "https://stackoverflow.com/questions/48902847/cdi-observer-condition-in-dependent-bean">...</a>
+         * <a href=
+         * "https://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#conditional_observer_methods">...</a>
          * <p>
-         * Removed conditional observer method because it is not supported 1.2 CDI spec.
+         * Removed conditional observer method because it is not supported 1.2
+         * CDI spec.
          * <p>
-         * Beans with scope @Dependent may not have conditional observer methods.
-         * If a bean with scope @Dependent has an observer method declared receive=IF_EXISTS,
-         * the container automatically detects the problem and treats it as a definition error.
+         * Beans with scope @Dependent may not have conditional observer
+         * methods. If a bean with scope @Dependent has an observer method
+         * declared receive=IF_EXISTS, the container automatically detects the
+         * problem and treats it as a definition error.
          */
-        private void onAfterNavigation(
-                @Observes AfterNavigationEvent event) {
+        private void onAfterNavigation(@Observes AfterNavigationEvent event) {
+            UI ui = event.getLocationChangeEvent().getUI();
+            Instantiator instantiator = Instantiator.get(ui);
             Set<Class<?>> activeChain = event.getActiveChain().stream()
-                    .map(Object::getClass).collect(Collectors.toSet());
+                    .map(instantiator::getApplicationClass)
+                    .collect(Collectors.toSet());
 
-            destroyDescopedBeans(event.getLocationChangeEvent().getUI(),
-                    activeChain);
+            destroyDescopedBeans(ui, activeChain);
 
         }
 

--- a/runtime/src/test/java/com/vaadin/quarkus/context/RouteContextualStorageManagerTest.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/context/RouteContextualStorageManagerTest.java
@@ -28,6 +28,12 @@ import java.util.function.Supplier;
 
 import io.quarkus.arc.InjectableBean;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.modifier.SyntheticState;
+import net.bytebuddy.description.modifier.Visibility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -204,6 +210,39 @@ public class RouteContextualStorageManagerTest {
 
         Assertions.assertTrue(destroyedBeans.contains(bean1));
         Assertions.assertTrue(destroyedBeans.contains(bean2));
+    }
+
+    @Test
+    public void afterNavigation_proxySubclassInActiveChain_beansArePreserved()
+            throws Exception {
+        Mockito.when(event.getNavigationTarget())
+                .thenReturn((Class) Group1.class);
+        beforeNavigationTrigger.fire(event);
+
+        MemberOfGroup1 bean1 = getMemberOfGroupProducer(contextual).get();
+        bean1.setState(STATE);
+
+        // Simulate Arc proxy subclass in active chain:
+        // Arc creates a synthetic subclass (e.g. FooView_Subclass) when
+        // proxying a view annotated with security annotations.
+        // Use ByteBuddy with ACC_SYNTHETIC to match Arc's behavior.
+        Class<? extends Group1> proxyClass = new ByteBuddy()
+                .subclass(Group1.class)
+                .modifiers(Visibility.PUBLIC, SyntheticState.SYNTHETIC).make()
+                .load(Group1.class.getClassLoader()).getLoaded()
+                .asSubclass(Group1.class);
+        Assertions.assertTrue(proxyClass.isSynthetic(),
+                "Generated proxy class should be synthetic");
+        Group1 proxyInstance = proxyClass.getDeclaredConstructor()
+                .newInstance();
+
+        Mockito.when(afterEvent.getActiveChain())
+                .thenReturn(Collections.singletonList(proxyInstance));
+        afterNavigationTrigger.fire(afterEvent);
+
+        Assertions.assertFalse(destroyedBeans.contains(bean1),
+                "Route-scoped bean should not be destroyed when the active "
+                        + "chain contains a proxy subclass of the owner");
     }
 
     @Test

--- a/runtime/src/test/java/com/vaadin/quarkus/context/ServiceUnderTestContext.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/context/ServiceUnderTestContext.java
@@ -25,6 +25,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import java.util.Set;
 
 import com.vaadin.flow.server.ServiceDestroyEvent;
+import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.VaadinService;
 import com.vaadin.quarkus.QuarkusVaadinServletService;
 import com.vaadin.quarkus.TestQuarkusVaadinServletService;
@@ -43,6 +44,11 @@ public class ServiceUnderTestContext implements UnderTestContext {
     public void activate() {
         NDX++;
         service = new TestQuarkusVaadinServletService(beanManager, NDX + "");
+        try {
+            service.init();
+        } catch (ServiceException e) {
+            throw new RuntimeException(e);
+        }
         VaadinService.setCurrent(service);
     }
 


### PR DESCRIPTION
When a route view is proxied by Quarkus Arc (e.g. due to an interceptor binding), its `@RouteScoped` beans are incorrectly destroyed during `afterNavigation`. The active chain contains proxy instances whose class doesn't match the original owner class stored in the route context.

Use `Instantiator.getApplicationClass()` to unwrap proxy classes in the active navigation chain before comparing with owners.

Also fix `UselessInterceptor` to be a proper CDI interceptor (was missing `@Interceptor` and `@AroundInvoke`), so the `@Useless` binding actually triggers proxy subclass creation.

Fixes #276