### PR TITLE
chore: bump project version to 3.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "com.vaadin:*"
+      - dependency-name: "io.quarkus:*" # managed manually to pin latest LTS version
+

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # vaadin-quarkus
 An extension to Quarkus to support Vaadin Flow.
 
-Supports Quarkus 3.32+
+Supports Quarkus 3.33+
 
 To try it out, you can get a project https://github.com/vaadin/base-starter-flow-quarkus/
 
-This branch is compatible with upcoming Vaadin 25.1+ platform versions and uses Quarkus 3.32 (LTS). See other branches for other Vaadin versions:
+This branch is compatible with upcoming Vaadin 25.2+ platform versions and uses Quarkus 3.33 (LTS). See other branches for other Vaadin versions:
 
+* 3.2 for Vaadin 25.2 and Quarkus 3.33
 * 3.1 for Vaadin 25.1 and Quarkus 3.32
 * 3.0 for Vaadin 25.0 and Quarkus 3.32
 * 2.2 for Vaadin 24 and Quarkus 3.20
 * 1.1 for Vaadin 23 and Quarkus 2
 
-> **NOTE:** The minimum supported Quarkus version for Vaadin 25.0 has been raised from 3.27 LTS to 3.32 LTS. This change is required because Flow now depends on Jackson 3.1.x and Jackson Annotations 2.21.x to address a security vulnerability.
+> **NOTE:** The minimum supported Quarkus version for Vaadin 25.0 has been raised from 3.27 LTS to 3.32. This change is required because Flow now depends on Jackson 3.1.x and Jackson Annotations 2.21.x to address a security vulnerability.
 
 ## devUI URL
 After executing the quarkus project with dev profile `mvn quarkus:dev`, the devUI can be accessed (with not overwritten configuration) at URL: `http://localhost:8080/q/dev-ui/extensions`

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-parent</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-deployment</artifactId>

--- a/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
+++ b/deployment/src/main/java/com/vaadin/quarkus/deployment/vaadinplugin/VaadinBuildTimeConfig.java
@@ -283,9 +283,9 @@ public interface VaadinBuildTimeConfig {
      * Minimum age (in days) a frontend (npm) package version must have before
      * npm, pnpm or bun is allowed to install it. Mitigates supply-chain attacks
      * where a compromised version is briefly available on the registry.
-     * Defaults to {@code 0} (disabled); set to a positive value to enable.
-     * Requires pnpm &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
+     * Defaults to {@code 1} day; set to {@code 0} to disable. Requires pnpm
+     * &ge; 10.16.0 or bun &ge; 1.3.0 when those tools are used.
      */
-    @WithDefault("0")
+    @WithDefault("1")
     int minimumFrontendPackageAgeDays();
 }

--- a/integration-tests/codestarts/pom.xml
+++ b/integration-tests/codestarts/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-codestarts-tests</artifactId>

--- a/integration-tests/common-test-code/pom.xml
+++ b/integration-tests/common-test-code/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-common-test-code</artifactId>

--- a/integration-tests/custom-websocket-dependency/pom.xml
+++ b/integration-tests/custom-websocket-dependency/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/integration-tests/development/pom.xml
+++ b/integration-tests/development/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-development-tests</artifactId>

--- a/integration-tests/embedded-plugin/pom.xml
+++ b/integration-tests/embedded-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-embedded-plugin-tests</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-parent</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-integration-tests</artifactId>

--- a/integration-tests/production/pom.xml
+++ b/integration-tests/production/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus-production-tests</artifactId>

--- a/integration-tests/reusable-theme/pom.xml
+++ b/integration-tests/reusable-theme/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>reusable-theme</artifactId>

--- a/integration-tests/test-addons/addon-with-jandex/pom.xml
+++ b/integration-tests/test-addons/addon-with-jandex/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/integration-tests/test-addons/addon-without-jandex/pom.xml
+++ b/integration-tests/test-addons/addon-without-jandex/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-integration-tests</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.vaadin</groupId>
   <artifactId>vaadin-quarkus-parent</artifactId>
-  <version>3.1-SNAPSHOT</version>
+  <version>3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Vaadin Quarkus - Parent</name>
@@ -40,10 +40,8 @@
     <failsafe-plugin.version>${surefire-plugin.version}</failsafe-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
 
-    <vaadin.flow.version>25.1-SNAPSHOT</vaadin.flow.version>
-    <quarkus.version>3.32.0</quarkus.version>
-    <open.telemetry.alpha.version>1.16.0-alpha</open.telemetry.alpha.version>
-    <open.telemetry.version>1.16.0</open.telemetry.version>
+    <vaadin.flow.version>25.2-SNAPSHOT</vaadin.flow.version>
+    <quarkus.version>3.33.0</quarkus.version>
 
     <surefire.excludedGroups>slow</surefire.excludedGroups>
   </properties>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.vaadin</groupId>
     <artifactId>vaadin-quarkus-parent</artifactId>
-    <version>3.1-SNAPSHOT</version>
+    <version>3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>vaadin-quarkus</artifactId>


### PR DESCRIPTION
Upgrade Vaadin to 25.2 and Quarkus to latest 3.33 LTS. Aligns minimumFrontendPackageAgeDays default value with Maven and Gradle plugins.
Adds dependabot configuration to keep dependencies and plugins up to date.
