### PR TITLE
chore: exclude vaadin-prereleases from ecosystem CI Maven mirror

### DIFF
--- a/.github/quarkus-ecosystem-test
+++ b/.github/quarkus-ecosystem-test
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -e
 
+# The upstream settings file mirrors external:* to the Google Maven Central
+# mirror (quarkusio/quarkus-ecosystem-ci#226), which would swallow requests
+# for the vaadin-prereleases repository. Exclude it from the mirror.
+if grep -q '<mirrorOf>external:\*</mirrorOf>' .github/quarkus-ecosystem-maven-settings.xml; then
+  sed -i 's|<mirrorOf>external:\*</mirrorOf>|<mirrorOf>external:*,!vaadin-prereleases</mirrorOf>|' \
+    .github/quarkus-ecosystem-maven-settings.xml
+fi
+
 # update the versions
 mvn --settings .github/quarkus-ecosystem-maven-settings.xml -B versions:set-property -Dproperty=quarkus.version -DnewVersion=${QUARKUS_VERSION} -DgenerateBackupPoms=false
 


### PR DESCRIPTION
The Quarkus ecosystem CI maven settings now mirror external:* to the Google Maven Central mirror (quarkusio/quarkus-ecosystem-ci#226). The mirror also captures requests for the vaadin-prereleases repository, which does not exist on the mirror, breaking the snapshot build.

Patch the settings file copied by the upstream setup-and-test script before running Maven, excluding vaadin-prereleases from the mirror so it is resolved directly from https://maven.vaadin.com/vaadin-prereleases/.
