### PR TITLE
fix: read Vaadin configuration from MicroProfile Config (#309)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ This branch is compatible with upcoming Vaadin 25.2+ platform versions and uses 
 
 > **NOTE:** The minimum supported Quarkus version for Vaadin 25.0 has been raised from 3.27 LTS to 3.32. This change is required because Flow now depends on Jackson 3.1.x and Jackson Annotations 2.21.x to address a security vulnerability.
 
+## Configuration
+
+Vaadin configuration parameters can be set through MicroProfile Config, i.e. in `application.properties` or `application.yaml`, using the `vaadin.` prefix. The part after the prefix is the standard Vaadin init parameter name (see `com.vaadin.flow.server.InitParameters`). For example:
+
+```properties
+vaadin.heartbeatInterval=120
+vaadin.closeIdleSessions=true
+```
+
+Values defined this way override the corresponding servlet init parameters declared via `@WebServlet` / `@WebInitParam`.
+
 ## devUI URL
 After executing the quarkus project with dev profile `mvn quarkus:dev`, the devUI can be accessed (with not overwritten configuration) at URL: `http://localhost:8080/q/dev-ui/extensions`
 

--- a/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServlet.java
+++ b/runtime/src/main/java/com/vaadin/quarkus/QuarkusVaadinServlet.java
@@ -16,7 +16,13 @@
 package com.vaadin.quarkus;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.inject.Inject;
@@ -25,7 +31,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import com.vaadin.flow.function.DeploymentConfiguration;
+import com.vaadin.flow.server.InitParameters;
 import com.vaadin.flow.server.ServiceException;
 import com.vaadin.flow.server.VaadinServlet;
 import com.vaadin.flow.server.VaadinServletService;
@@ -47,6 +57,25 @@ public class QuarkusVaadinServlet extends VaadinServlet {
 
     private static final ThreadLocal<Optional<String>> SERVLET_NAME = new ThreadLocal<>();
 
+    /**
+     * Prefix used for Vaadin configuration properties defined through
+     * MicroProfile Config (e.g. in {@code application.properties} or
+     * {@code application.yaml}), matching the convention used by the Vaadin
+     * Spring integration.
+     */
+    private static final String CONFIGURATION_PREFIX = "vaadin.";
+
+    /**
+     * Names of all known Vaadin configuration parameters, as declared by the
+     * {@link InitParameters} constants.
+     */
+    private static final List<String> CONFIGURATION_PROPERTY_NAMES = Stream
+            .of(InitParameters.class.getDeclaredFields())
+            .filter(field -> Modifier.isStatic(field.getModifiers())
+                    && field.getType() == String.class)
+            .map(QuarkusVaadinServlet::getStringValue)
+            .collect(Collectors.toList());
+
     @Override
     protected VaadinServletService createServletService(
             final DeploymentConfiguration configuration)
@@ -56,6 +85,47 @@ public class QuarkusVaadinServlet extends VaadinServlet {
                 this, configuration, this.beanManager);
         service.init();
         return service;
+    }
+
+    @Override
+    protected DeploymentConfiguration createDeploymentConfiguration(
+            final Properties initParameters) {
+        applyConfigurationProperties(initParameters);
+        return super.createDeploymentConfiguration(initParameters);
+    }
+
+    /**
+     * Copies Vaadin configuration properties defined through MicroProfile
+     * Config (e.g. in {@code application.properties} or
+     * {@code application.yaml}) into the servlet init parameters, so that they
+     * are taken into account when building the {@link DeploymentConfiguration}.
+     * <p>
+     * Each known Vaadin parameter is looked up using the {@code vaadin.} prefix
+     * and, when present, overrides any value coming from servlet init
+     * parameters.
+     *
+     * @param initParameters
+     *            the init parameters to enrich, not {@code null}
+     */
+    static void applyConfigurationProperties(
+            final Properties initParameters) {
+        final Config config = ConfigProvider.getConfig();
+        for (final String name : CONFIGURATION_PROPERTY_NAMES) {
+            config.getOptionalValue(CONFIGURATION_PREFIX + name, String.class)
+                    .ifPresent(value -> initParameters.setProperty(name,
+                            value));
+        }
+    }
+
+    private static String getStringValue(final Field field) {
+        try {
+            return (String) field.get(null);
+        } catch (final IllegalAccessException e) {
+            throw new IllegalStateException(
+                    "Unable to read Vaadin init parameter name from field "
+                            + field.getName(),
+                    e);
+        }
     }
 
     @Override

--- a/runtime/src/test/java/com/vaadin/quarkus/QuarkusVaadinServletConfigurationTest.java
+++ b/runtime/src/test/java/com/vaadin/quarkus/QuarkusVaadinServletConfigurationTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.vaadin.quarkus;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.vaadin.flow.server.InitParameters;
+
+/**
+ * Verifies that Vaadin configuration defined through MicroProfile Config (e.g.
+ * in {@code application.properties}) is copied into the servlet init parameters
+ * by {@link QuarkusVaadinServlet}.
+ *
+ * @see <a href="https://github.com/vaadin/quarkus/issues/309">vaadin/quarkus
+ *      #309</a>
+ */
+public class QuarkusVaadinServletConfigurationTest {
+
+    @AfterEach
+    public void clearProperties() {
+        System.clearProperty(
+                "vaadin." + InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL);
+        System.clearProperty("vaadin."
+                + InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS);
+    }
+
+    @Test
+    public void configurationProperties_copiedIntoInitParameters() {
+        System.setProperty("vaadin."
+                + InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL, "120");
+        System.setProperty("vaadin."
+                + InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS, "true");
+
+        Properties initParameters = new Properties();
+        QuarkusVaadinServlet.applyConfigurationProperties(initParameters);
+
+        Assertions.assertEquals("120", initParameters.getProperty(
+                InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL));
+        Assertions.assertEquals("true", initParameters.getProperty(
+                InitParameters.SERVLET_PARAMETER_CLOSE_IDLE_SESSIONS));
+    }
+
+    @Test
+    public void configurationProperties_overrideExistingInitParameters() {
+        System.setProperty("vaadin."
+                + InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL, "120");
+
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL, "300");
+
+        QuarkusVaadinServlet.applyConfigurationProperties(initParameters);
+
+        Assertions.assertEquals("120", initParameters.getProperty(
+                InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL));
+    }
+
+    @Test
+    public void noConfigurationProperties_initParametersUnchanged() {
+        Properties initParameters = new Properties();
+        initParameters.setProperty(
+                InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL, "300");
+
+        QuarkusVaadinServlet.applyConfigurationProperties(initParameters);
+
+        Assertions.assertEquals("300", initParameters.getProperty(
+                InitParameters.SERVLET_PARAMETER_HEARTBEAT_INTERVAL));
+    }
+}


### PR DESCRIPTION
Vaadin parameters set in application.properties / application.yaml (e.g. vaadin.heartbeatInterval, vaadin.closeIdleSessions) were ignored because QuarkusVaadinServlet built the DeploymentConfiguration from servlet init parameters only.

Override createDeploymentConfiguration(Properties) to merge values from ConfigProvider into the init parameters, looking up each known Vaadin parameter (from InitParameters) under the vaadin. prefix. This mirrors the Vaadin Spring integration, where config values take precedence over annotation-based init parameters.

Fixes https://github.com/vaadin/quarkus/issues/309
