### PR TITLE
fix: use vaadin.version property for extension dependency in codestart

### DIFF
--- a/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/CodestartTestUtils.java
+++ b/integration-tests/codestarts/src/test/java/com/vaadin/flow/quarkus/it/CodestartTestUtils.java
@@ -41,7 +41,9 @@ final class CodestartTestUtils {
                 .filteredOn(dep -> "com.vaadin".equals(dep.getGroupId())
                         && "vaadin-quarkus-extension"
                                 .equals(dep.getArtifactId()))
-                .hasSize(1);
+                .hasSize(1).element(0)
+                .satisfies(dep -> soft.assertThat(dep.getVersion())
+                        .contains("${vaadin.version}"));
     }
 
     static void assertThatHasProductionProfile(Model pom, SoftAssertions soft) {

--- a/runtime/src/main/codestarts/quarkus/flow-codestart/base/pom.xml.tpl.qute
+++ b/runtime/src/main/codestarts/quarkus/flow-codestart/base/pom.xml.tpl.qute
@@ -18,13 +18,19 @@
 
     <dependencies>
 
-        {#if !input['selected-extensions-ga'].contains("com.vaadin:vaadin-quarkus-extension") }
+        <!--
+        Always declare the extension dependency using the vaadin.version property.
+        When vaadin-quarkus-extension is the selected extension (e.g. through the
+        Vaadin platform, `-Dextensions=vaadin`), Quarkus injects the same
+        dependency with a hard-coded version. The smart POM merge collapses both
+        entries by groupId:artifactId and, being source-dominant, keeps this
+        property-based version.
+        -->
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-quarkus-extension</artifactId>
             <version>$\{vaadin.version\}</version>
         </dependency>
-        {/if}
 
         <!-- Uncomment the following if you are using any of the Pro components -->
         <!--


### PR DESCRIPTION
The generated POM imported vaadin-bom via ${vaadin.version} but pinned a hard-coded version on the vaadin-quarkus-extension dependency.

The codestart declared the dependency with ${vaadin.version} but guarded it behind `!selected-extensions-ga.contains("com.vaadin:vaadin-quarkus-extension")`. In the platform build (`-Dextensions=vaadin`) that GA is the selected extension, so the guard skipped the codestart's entry and Quarkus injected the extension with a hard-coded version instead.

Remove the guard so the codestart always declares the dependency with ${vaadin.version}. The smart POM merge collapses it with Quarkus's injected entry by groupId:artifactId, keeping the property-based version.

Fixes #316
